### PR TITLE
Change 'utils' library to 'http.utils'

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library utils;
+library http.utils;
 
 import 'dart:async';
 import 'dart:convert';


### PR DESCRIPTION
It is important to do this because using a generic 'utils' library can conflict with other packages and even the user of the library.