### PR TITLE
Update from package:unittest to package:test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,6 @@ dependencies:
   path: ">=0.9.0 <2.0.0"
   stack_trace: ">=0.9.1 <2.0.0"
 dev_dependencies:
-  unittest: ">=0.9.0 <0.12.0"
+  test: ">=0.12.0 <0.13.0"
 environment:
   sdk: ">=1.9.0 <2.0.0"

--- a/test/html/client_test.dart
+++ b/test/html/client_test.dart
@@ -2,9 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("browser")
 import 'package:http/http.dart' as http;
 import 'package:http/browser_client.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/html/streamed_request_test.dart
+++ b/test/html/streamed_request_test.dart
@@ -2,9 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("browser")
 import 'package:http/http.dart' as http;
 import 'package:http/browser_client.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/io/client_test.dart
+++ b/test/io/client_test.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/io/http_test.dart
+++ b/test/io/http_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/io/multipart_test.dart
+++ b/test/io/multipart_test.dart
@@ -2,12 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
 import 'dart:async';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/io/request_test.dart
+++ b/test/io/request_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/io/streamed_request_test.dart
+++ b/test/io/streamed_request_test.dart
@@ -2,10 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@TestOn("vm")
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/io/utils.dart
+++ b/test/io/utils.dart
@@ -8,7 +8,7 @@ import 'dart:io';
 
 import 'package:http/http.dart';
 import 'package:http/src/utils.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 export '../utils.dart';
 

--- a/test/mock_client_test.dart
+++ b/test/mock_client_test.dart
@@ -8,7 +8,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:http/src/utils.dart';
 import 'package:http/testing.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/multipart_test.dart
+++ b/test/multipart_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('()', () {

--- a/test/streamed_request_test.dart
+++ b/test/streamed_request_test.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:http/http.dart' as http;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 import 'utils.dart';
 

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 /// A dummy URL for constructing requests that won't be sent.
 Uri get dummyUrl => Uri.parse('http://dartlang.org/');


### PR DESCRIPTION
After doing this, all tests pass except the ones that rely on the /echo server. I am unsure as to what it was and where I can get it, so I made a new echo server in a separate pull request. With that pull requests, all tests pass.
