### PR TITLE
Update URL for reporting bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,4 @@ main() async {
 
 ## Filing issues
 
-Please file issues for the http package at [http://dartbug.com/new][bugs].
-
-[bugs]: http://dartbug.com/new
-[docs]: https://api.dartlang.org/docs/channels/dev/latest/http.html
+Please file issues for the http package at <https://github.com/dart-lang/http/issues>.


### PR DESCRIPTION
The current URL links to <https://github.com/dart-lang/sdk/issues/new> instead of <https://github.com/dart-lang/http/issues>.

Also remove the stale `[docs]` link.

Fixes #3.