### PR TITLE
Updating .gitignore to latest from GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,27 @@
-# Don’t commit the following directories created by pub.
+# See https://www.dartlang.org/tools/private-files.html
+
+# Files and directories created by pub
 .buildlog
+.packages
+.project
 .pub/
 build/
-packages
-.packages
+**/packages/
 
-# Or the files created by dart2js.
+# Files created by dart2js
+# (Most Dart developers will use pub build to compile Dart, use/modify these
+#  rules if you intend to use dart2js directly
+#  Convention is to use extension '.dart.js' for Dart compiled to Javascript to
+#  differentiate from explicit Javascript files)
 *.dart.js
-*.js_
+*.part.js
 *.js.deps
 *.js.map
+*.info.json
 
-# Include when developing application packages.
+# Directory created by dartdoc
+doc/api/
+
+# Don't commit pubspec lock file
+# (Library packages only! Remove pattern if developing an application package)
 pubspec.lock


### PR DESCRIPTION
Updating to latest revision of https://github.com/github/gitignore/blob/master/Dart.gitignore