### PR TITLE
Properly handle `null` field values when encoding requests.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -13,6 +13,10 @@ import 'byte_stream.dart';
 ///     mapToQuery({"foo": "bar", "baz": "bang"});
 ///     //=> "foo=bar&baz=bang"
 String mapToQuery(Map<String, String> map, {Encoding encoding}) {
+  map.keys
+    .where((k) => (map[k] == null)).toList() // -- keys for null elements
+    .forEach(map.remove);
+
   var pairs = <List<String>>[];
   map.forEach((key, value) =>
       pairs.add([Uri.encodeQueryComponent(key, encoding: encoding),

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -13,9 +13,8 @@ import 'byte_stream.dart';
 ///     mapToQuery({"foo": "bar", "baz": "bang"});
 ///     //=> "foo=bar&baz=bang"
 String mapToQuery(Map<String, String> map, {Encoding encoding}) {
-  map.keys
-    .where((k) => (map[k] == null)).toList() // -- keys for null elements
-    .forEach(map.remove);
+  var nullKeys = map.keys.where((k) => (map[k] == null)).toList();
+  nullKeys.forEach(map.remove); // -- remove elements with null values
 
   var pairs = <List<String>>[];
   map.forEach((key, value) =>

--- a/test/io/http_test.dart
+++ b/test/io/http_test.dart
@@ -125,7 +125,8 @@ main() {
           'User-Agent': 'Dart'
         }, body: {
           'some-field': 'value',
-          'other-field': 'other value'
+          'other-field': 'other value',
+          'null-field': null
         }).then((response) {
           expect(response.statusCode, equals(200));
           expect(response.body, parse(equals({
@@ -229,7 +230,8 @@ main() {
           'User-Agent': 'Dart'
         }, body: {
           'some-field': 'value',
-          'other-field': 'other value'
+          'other-field': 'other value',
+          'null-field': null
         }).then((response) {
           expect(response.statusCode, equals(200));
           expect(response.body, parse(equals({
@@ -333,7 +335,8 @@ main() {
           'User-Agent': 'Dart'
         }, body: {
           'some-field': 'value',
-          'other-field': 'other value'
+          'other-field': 'other value',
+          'null-field': null
         }).then((response) {
           expect(response.statusCode, equals(200));
           expect(response.body, parse(equals({


### PR DESCRIPTION
This fixes Issue #75 