### PR TITLE
Remove the "Filing Bugs" section of the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,3 @@ main() async {
   print('Response body: ${response.body}');
 }
 ```
-
-## Filing issues
-
-Please file issues for the http package at [http://dartbug.com/new][bugs].
-
-[bugs]: http://dartbug.com/new
-[docs]: https://api.dartlang.org/docs/channels/dev/latest/http.html


### PR DESCRIPTION
Most packages don't have this section, and it's pretty clear that users
are supposed to file issues on GitHub.

Closes #68