### PR TITLE
Use content-length header directly for dart:io

### DIFF
--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -31,9 +31,6 @@ class IOClient extends BaseClient {
       ioRequest
           ..followRedirects = context['io.followRedirects'] ?? true
           ..maxRedirects = context['io.maxRedirects'] ?? 5
-          ..contentLength = request.contentLength == null
-              ? -1
-              : request.contentLength
           ..persistentConnection = context['io.persistentConnection'] ?? true;
       request.headers.forEach((name, value) {
         ioRequest.headers.set(name, value);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -330,6 +330,7 @@ void main() {
             'method': 'DELETE',
             'path': '/',
             'headers': {
+              'content-length': ['0'],
               'user-agent': [userAgent()],
               'x-random-header': ['Value'],
               'x-other-header': ['Other Value']


### PR DESCRIPTION
The `dart:io` path failed client tests where `content-length` was expected to be set. The `dart:html` path was successful for these tests already.

One solution that seemed to imply a bug in `dart:io` was moving the `headers.set` above the setting of `contentLength`. This worked but this seems to be a better path since by default `contentLength` is -1 and if it is not set by `Message` then the behavior is the same. So the code is just deleted.

Additionally it appears that in both Chrome and `dart:io` the `content-length` header is stripped when the GET method is called. It is not stripped for DELETE so the test was updated accordingly.