### PR TITLE
Add http package prefix for import consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class UserAgentClient extends http.BaseClient {
 
   UserAgentClient(this.userAgent, this._inner);
 
-  Future<StreamedResponse> send(BaseRequest request) {
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
     request.headers['user-agent'] = userAgent;
     return _inner.send(request);
   }


### PR DESCRIPTION
In the example, `Client` and `BaseClient` are package qualified, but `BaseRequest` and `StreamedResponse` aren't.