### PR TITLE
Stop depending on stack_trace

### DIFF
--- a/lib/browser_client.dart
+++ b/lib/browser_client.dart
@@ -7,7 +7,6 @@ import 'dart:html';
 import 'dart:typed_data';
 
 import 'package:async/async.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import 'src/base_client.dart';
 import 'src/exception.dart';
@@ -64,7 +63,7 @@ class BrowserClient extends BaseClient {
       reader.onError.first.then((error) {
         completer.completeError(
             new ClientException(error.toString(), request.url),
-            new Chain.current());
+            StackTrace.current);
       });
 
       reader.readAsArrayBuffer(blob);
@@ -75,7 +74,7 @@ class BrowserClient extends BaseClient {
       // specific information about the error itself.
       completer.completeError(
           new ClientException("XMLHttpRequest error.", request.url),
-          new Chain.current());
+          StackTrace.current);
     });
 
     xhr.send(bytes);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ dependencies:
   collection: "^1.5.0"
   http_parser: ">=0.0.1 <4.0.0"
   path: ">=0.9.0 <2.0.0"
-  stack_trace: ">=0.9.1 <2.0.0"
 dev_dependencies:
   test: "^0.12.18"
 # Override dependency on package_resolver to enable test


### PR DESCRIPTION
At this point, we're only using this for Chain.current which might as
well just be StackTrace.current.