### PR TITLE
Stop depending on stack_trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.3+16
+
+* Stop depending on the `stack_trace` package.
+
 ## 0.11.3+15
 
 * Declare support for `async` 2.0.0.

--- a/lib/browser_client.dart
+++ b/lib/browser_client.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';
 
-import 'package:stack_trace/stack_trace.dart';
-
 import 'src/base_client.dart';
 import 'src/base_request.dart';
 import 'src/byte_stream.dart';
@@ -71,7 +69,7 @@ class BrowserClient extends BaseClient {
       reader.onError.first.then((error) {
         completer.completeError(
             new ClientException(error.toString(), request.url),
-            new Chain.current());
+            StackTrace.current);
       });
 
       reader.readAsArrayBuffer(blob);
@@ -82,7 +80,7 @@ class BrowserClient extends BaseClient {
       // specific information about the error itself.
       completer.completeError(
           new ClientException("XMLHttpRequest error.", request.url),
-          new Chain.current());
+          StackTrace.current);
     });
 
     xhr.send(bytes);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.11.3+15
+version: 0.11.3+16
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/http
 description: A composable, Future-based API for making HTTP requests.
@@ -8,7 +8,6 @@ dependencies:
   collection: "^1.5.0"
   http_parser: ">=0.0.1 <4.0.0"
   path: ">=0.9.0 <2.0.0"
-  stack_trace: ">=0.9.1 <2.0.0"
 dev_dependencies:
   unittest: ">=0.9.0 <0.12.0"
 environment:


### PR DESCRIPTION
At this point, we're only using this for Chain.current which might as
well just be StackTrace.current.

This is a cherry-pick of 77d470ac45a4c8972fe5ad4e58170dc0607240a0 into
the 0.11.x branch.

Closes #122