### PR TITLE
Add content type library

### DIFF
--- a/lib/src/content_type.dart
+++ b/lib/src/content_type.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:http_parser/http_parser.dart';
+
+/// Returns the [Encoding] that corresponds to [charset].
+///
+/// Returns [fallback] if [charset] is null or if no [Encoding] was found that
+/// corresponds to [charset].
+Encoding encodingForCharset(String charset, [Encoding fallback = LATIN1]) {
+  if (charset == null) return fallback;
+  var encoding = Encoding.getByName(charset);
+  return encoding == null ? fallback : encoding;
+}
+
+/// Returns the name of the charset that corresponds to the [contentType].
+///
+/// If [contentType] is `null` then no charset has been specified and `null`
+/// will be returned. If the [contentType] is present then it will be parsed
+/// and the value of `charset` is returned.
+String charsetForContentType(String contentType) {
+  if (contentType == null) return null;
+  var mediaType = new MediaType.parse(contentType);
+  return mediaType.parameters['charset'];
+}
+
+/// Determines the body encoding either through an explicit [encoding] or
+/// through the [contentType] header.
+///
+/// If an explicit [encoding] is set then this will be used and will override
+/// any `charset` from [contentType]. Otherwise the [contentType]'s `charset`
+/// will be used. If neither are provided `null` will be returned.
+Encoding determineEncoding(Encoding encoding, String contentType) {
+  if (encoding != null) return encoding;
+  var charset = charsetForContentType(contentType);
+  return encodingForCharset(charset, null);
+}

--- a/lib/src/content_type.dart
+++ b/lib/src/content_type.dart
@@ -25,19 +25,6 @@ Encoding encodingForMediaType(MediaType type, [Encoding fallback = LATIN1]) {
   return encodingForCharset(type.parameters['charset'], fallback);
 }
 
-/// Determines the body encoding either through an explicit [encoding] or
-/// through the [contentType] header.
-///
-/// If an explicit [encoding] is set then this will be used and will override
-/// any `charset` from [contentType]. Otherwise the [contentType]'s `charset`
-/// will be used. If neither are provided [fallback] will be returned.
-Encoding determineEncoding(Encoding encoding, String contentType,
-    [Encoding fallback = LATIN1]) {
-  if (encoding != null) return encoding;
-  if (contentType == null) return fallback;
-  return encodingForMediaType(new MediaType.parse(contentType), fallback);
-}
-
 /// Modifies the media [type]'s [encoding].
 MediaType modifyEncoding(MediaType type, Encoding encoding) =>
     type.change(parameters: <String, String>{'charset': encoding.name});

--- a/lib/src/content_type.dart
+++ b/lib/src/content_type.dart
@@ -16,15 +16,13 @@ Encoding encodingForCharset(String charset, [Encoding fallback = LATIN1]) {
   return encoding == null ? fallback : encoding;
 }
 
-/// Returns the name of the charset that corresponds to the [contentType].
+/// Determines the encoding from the media [type].
 ///
-/// If [contentType] is `null` then no charset has been specified and `null`
-/// will be returned. If the [contentType] is present then it will be parsed
-/// and the value of `charset` is returned.
-String charsetForContentType(String contentType) {
-  if (contentType == null) return null;
-  var mediaType = new MediaType.parse(contentType);
-  return mediaType.parameters['charset'];
+/// Returns [fallback] if the charset is not specified in the [type] or if no
+/// [Encoding] was found that corresponds to the `charset`.
+Encoding encodingForMediaType(MediaType type, [Encoding fallback = LATIN1]) {
+  if (type == null) return fallback;
+  return encodingForCharset(type.parameters['charset'], fallback);
 }
 
 /// Determines the body encoding either through an explicit [encoding] or
@@ -32,9 +30,14 @@ String charsetForContentType(String contentType) {
 ///
 /// If an explicit [encoding] is set then this will be used and will override
 /// any `charset` from [contentType]. Otherwise the [contentType]'s `charset`
-/// will be used. If neither are provided `null` will be returned.
-Encoding determineEncoding(Encoding encoding, String contentType) {
+/// will be used. If neither are provided [fallback] will be returned.
+Encoding determineEncoding(Encoding encoding, String contentType,
+    [Encoding fallback = LATIN1]) {
   if (encoding != null) return encoding;
-  var charset = charsetForContentType(contentType);
-  return encodingForCharset(charset, null);
+  if (contentType == null) return fallback;
+  return encodingForMediaType(new MediaType.parse(contentType), fallback);
 }
+
+/// Modifies the media [type]'s [encoding].
+MediaType modifyEncoding(MediaType type, Encoding encoding) =>
+    type.change(parameters: <String, String>{'charset': encoding.name});

--- a/lib/src/content_type.dart
+++ b/lib/src/content_type.dart
@@ -8,23 +8,18 @@ import 'package:http_parser/http_parser.dart';
 
 /// Returns the [Encoding] that corresponds to [charset].
 ///
-/// Returns [fallback] if [charset] is null or if no [Encoding] was found that
+/// Returns `null` if [charset] is `null` or if no [Encoding] was found that
 /// corresponds to [charset].
-Encoding encodingForCharset(String charset, [Encoding fallback = LATIN1]) {
-  if (charset == null) return fallback;
-  var encoding = Encoding.getByName(charset);
-  return encoding == null ? fallback : encoding;
+Encoding encodingForCharset(String charset) {
+  if (charset == null) return null;
+  return Encoding.getByName(charset);
 }
 
 /// Determines the encoding from the media [type].
 ///
-/// Returns [fallback] if the charset is not specified in the [type] or if no
+/// Returns `null` if the charset is not specified in the [type] or if no
 /// [Encoding] was found that corresponds to the `charset`.
-Encoding encodingForMediaType(MediaType type, [Encoding fallback = LATIN1]) {
-  if (type == null) return fallback;
-  return encodingForCharset(type.parameters['charset'], fallback);
+Encoding encodingForMediaType(MediaType type) {
+  if (type == null) return null;
+  return encodingForCharset(type.parameters['charset']);
 }
-
-/// Modifies the media [type]'s [encoding].
-MediaType modifyEncoding(MediaType type, Encoding encoding) =>
-    type.change(parameters: <String, String>{'charset': encoding.name});

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -83,7 +83,8 @@ abstract class Message {
     if (_contentLengthCache != null) return _contentLengthCache;
     var contentLengthHeader = getHeader(headers, 'content-length');
     if (contentLengthHeader == null) return null;
-    return _contentLengthCache = int.parse(contentLengthHeader);
+    _contentLengthCache = int.parse(contentLengthHeader);
+    return _contentLengthCache;
   }
 
   int _contentLengthCache;
@@ -112,7 +113,8 @@ abstract class Message {
     if (_contentTypeCache != null) return _contentTypeCache;
     var contentLengthHeader = getHeader(headers, 'content-type');
     if (contentLengthHeader == null) return null;
-    return _contentTypeCache = new MediaType.parse(contentLengthHeader);
+    _contentTypeCache = new MediaType.parse(contentLengthHeader);
+    return _contentTypeCache;
   }
 
   MediaType _contentTypeCache;

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -62,13 +62,7 @@ abstract class Message {
       {Encoding encoding,
       Map<String, String> headers,
       Map<String, Object> context})
-      : this._(
-            new Body(
-                body,
-                determineEncoding(
-                    encoding, getHeader(headers, 'content-type'), null)),
-            headers,
-            context);
+      : this._(new Body(body, encoding), headers, context);
 
   Message._(Body body, Map<String, String> headers, Map<String, Object> context)
       : _body = body,

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -103,7 +103,7 @@ abstract class Message {
   ///
   /// If [headers] doesn't have a Content-Type header or it specifies an
   /// encoding that [dart:convert] doesn't support, this will be `null`.
-  Encoding get encoding => encodingForMediaType(_contentType, null);
+  Encoding get encoding => encodingForMediaType(_contentType);
 
   /// The parsed version of the Content-Type header in [headers].
   ///

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:http_parser/http_parser.dart';
 
 import 'body.dart';
+import 'content_type.dart';
 import 'http_unmodifiable_map.dart';
 import 'utils.dart';
 
@@ -61,7 +62,13 @@ abstract class Message {
       {Encoding encoding,
       Map<String, String> headers,
       Map<String, Object> context})
-      : this._(new Body(body, encoding), headers, context);
+      : this._(
+            new Body(
+                body,
+                determineEncoding(
+                    encoding, getHeader(headers, 'content-type'))),
+            headers,
+            context);
 
   Message._(Body body, Map<String, String> headers, Map<String, Object> context)
       : _body = body,
@@ -84,6 +91,7 @@ abstract class Message {
     _contentLengthCache = int.parse(headers['content-length']);
     return _contentLengthCache;
   }
+
   int _contentLengthCache;
 
   /// The MIME type declared in [headers].
@@ -121,6 +129,7 @@ abstract class Message {
     _contentTypeCache = new MediaType.parse(headers['content-type']);
     return _contentTypeCache;
   }
+
   MediaType _contentTypeCache;
 
   /// Returns the message body as byte chunks.

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -66,7 +66,7 @@ abstract class Message {
             new Body(
                 body,
                 determineEncoding(
-                    encoding, getHeader(headers, 'content-type'))),
+                    encoding, getHeader(headers, 'content-type'), null)),
             headers,
             context);
 
@@ -87,9 +87,9 @@ abstract class Message {
   /// If not set, `null`.
   int get contentLength {
     if (_contentLengthCache != null) return _contentLengthCache;
-    if (!headers.containsKey('content-length')) return null;
-    _contentLengthCache = int.parse(headers['content-length']);
-    return _contentLengthCache;
+    var contentLengthHeader = getHeader(headers, 'content-length');
+    if (contentLengthHeader == null) return null;
+    return _contentLengthCache = int.parse(contentLengthHeader);
   }
 
   int _contentLengthCache;
@@ -100,11 +100,7 @@ abstract class Message {
   /// the MIME type, without any Content-Type parameters.
   ///
   /// If [headers] doesn't have a Content-Type header, this will be `null`.
-  String get mimeType {
-    var contentType = _contentType;
-    if (contentType == null) return null;
-    return contentType.mimeType;
-  }
+  String get mimeType => _contentType?.mimeType;
 
   /// The encoding of the body returned by [read].
   ///
@@ -113,21 +109,16 @@ abstract class Message {
   ///
   /// If [headers] doesn't have a Content-Type header or it specifies an
   /// encoding that [dart:convert] doesn't support, this will be `null`.
-  Encoding get encoding {
-    var contentType = _contentType;
-    if (contentType == null) return null;
-    if (!contentType.parameters.containsKey('charset')) return null;
-    return Encoding.getByName(contentType.parameters['charset']);
-  }
+  Encoding get encoding => encodingForMediaType(_contentType, null);
 
   /// The parsed version of the Content-Type header in [headers].
   ///
   /// This is cached for efficient access.
   MediaType get _contentType {
     if (_contentTypeCache != null) return _contentTypeCache;
-    if (!headers.containsKey('content-type')) return null;
-    _contentTypeCache = new MediaType.parse(headers['content-type']);
-    return _contentTypeCache;
+    var contentLengthHeader = getHeader(headers, 'content-type');
+    if (contentLengthHeader == null) return null;
+    return _contentTypeCache = new MediaType.parse(contentLengthHeader);
   }
 
   MediaType _contentTypeCache;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -53,24 +53,6 @@ List<String> split1(String toSplit, String pattern) {
   ];
 }
 
-/// Returns the [Encoding] that corresponds to [charset]. Returns [fallback] if
-/// [charset] is null or if no [Encoding] was found that corresponds to
-/// [charset].
-Encoding encodingForCharset(String charset, [Encoding fallback = LATIN1]) {
-  if (charset == null) return fallback;
-  var encoding = Encoding.getByName(charset);
-  return encoding == null ? fallback : encoding;
-}
-
-
-/// Returns the [Encoding] that corresponds to [charset]. Throws a
-/// [FormatException] if no [Encoding] was found that corresponds to [charset].
-/// [charset] may not be null.
-Encoding requiredEncodingForCharset(String charset) {
-  var encoding = Encoding.getByName(charset);
-  if (encoding != null) return encoding;
-  throw new FormatException('Unsupported encoding "$charset".');
-}
 
 /// A regular expression that matches strings that are composed entirely of
 /// ASCII-compatible characters.


### PR DESCRIPTION
Consolidate content-type related code into a single library and start using it within `Message`.