### PR TITLE
Library cleanup and formatting

### DIFF
--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -12,110 +12,33 @@ import 'client.dart';
 import 'exception.dart';
 import 'request.dart';
 import 'response.dart';
+import 'utils.dart';
 
 /// The abstract base class for an HTTP client. This is a mixin-style class;
 /// subclasses only need to implement [send] and maybe [close], and then they
 /// get various convenience methods for free.
 abstract class BaseClient implements Client {
-  /// Sends an HTTP HEAD request with the given headers to the given URL, which
-  /// can be a [Uri] or a [String].
-  ///
-  /// For more fine-grained control over the request, use [send] instead.
   Future<Response> head(url, {Map<String, String> headers}) =>
-    send(new Request.head(url, headers: headers));
+      send(new Request.head(url, headers: headers));
 
-  /// Sends an HTTP GET request with the given headers to the given URL, which
-  /// can be a [Uri] or a [String].
-  ///
-  /// For more fine-grained control over the request, use [send] instead.
   Future<Response> get(url, {Map<String, String> headers}) =>
-    send(new Request.get(url, headers: headers));
+      send(new Request.get(url, headers: headers));
 
-  /// Sends an HTTP POST request with the given headers and body to the given
-  /// URL, which can be a [Uri] or a [String].
-  ///
-  /// [body] sets the body of the request. It can be a [String], a [List<int>]
-  /// or a [Map<String, String>]. If it's a String, it's encoded using
-  /// [encoding] and used as the body of the request. The content-type of the
-  /// request will default to "text/plain".
-  ///
-  /// If [body] is a List, it's used as a list of bytes for the body of the
-  /// request.
-  ///
-  /// If [body] is a Map, it's encoded as form fields using [encoding]. The
-  /// content-type of the request will be set to
-  /// `"application/x-www-form-urlencoded"`; this cannot be overridden.
-  ///
-  /// [encoding] defaults to UTF-8.
-  ///
-  /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> post(url, body, {Map<String, String> headers,
-      Encoding encoding}) =>
-    send(new Request.post(url, body, headers: headers,
-        encoding: encoding));
+  Future<Response> post(url, body,
+          {Map<String, String> headers, Encoding encoding}) =>
+      send(new Request.post(url, body, headers: headers, encoding: encoding));
 
-  /// Sends an HTTP PUT request with the given headers and body to the given
-  /// URL, which can be a [Uri] or a [String].
-  ///
-  /// [body] sets the body of the request. It can be a [String], a [List<int>]
-  /// or a [Map<String, String>]. If it's a String, it's encoded using
-  /// [encoding] and used as the body of the request. The content-type of the
-  /// request will default to "text/plain".
-  ///
-  /// If [body] is a List, it's used as a list of bytes for the body of the
-  /// request.
-  ///
-  /// If [body] is a Map, it's encoded as form fields using [encoding]. The
-  /// content-type of the request will be set to
-  /// `"application/x-www-form-urlencoded"`; this cannot be overridden.
-  ///
-  /// [encoding] defaults to UTF-8.
-  ///
-  /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> put(url, body, {Map<String, String> headers,
-      Encoding encoding}) =>
-    send(new Request.put(url, body, headers: headers,
-        encoding: encoding));
+  Future<Response> put(url, body,
+          {Map<String, String> headers, Encoding encoding}) =>
+      send(new Request.put(url, body, headers: headers, encoding: encoding));
 
-  /// Sends an HTTP PATCH request with the given headers and body to the given
-  /// URL, which can be a [Uri] or a [String].
-  ///
-  /// [body] sets the body of the request. It can be a [String], a [List<int>]
-  /// or a [Map<String, String>]. If it's a String, it's encoded using
-  /// [encoding] and used as the body of the request. The content-type of the
-  /// request will default to "text/plain".
-  ///
-  /// If [body] is a List, it's used as a list of bytes for the body of the
-  /// request.
-  ///
-  /// If [body] is a Map, it's encoded as form fields using [encoding]. The
-  /// content-type of the request will be set to
-  /// `"application/x-www-form-urlencoded"`; this cannot be overridden.
-  ///
-  /// [encoding] defaults to UTF-8.
-  ///
-  /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> patch(url, body, {Map<String, String> headers,
-      Encoding encoding}) =>
-    send(new Request.patch(url, body, headers: headers,
-        encoding: encoding));
+  Future<Response> patch(url, body,
+          {Map<String, String> headers, Encoding encoding}) =>
+      send(new Request.patch(url, body, headers: headers, encoding: encoding));
 
-  /// Sends an HTTP DELETE request with the given headers to the given URL,
-  /// which can be a [Uri] or a [String].
-  ///
-  /// For more fine-grained control over the request, use [send] instead.
   Future<Response> delete(url, {Map<String, String> headers}) =>
       send(new Request.delete(url, headers: headers));
 
-  /// Sends an HTTP GET request with the given headers to the given URL, which
-  /// can be a [Uri] or a [String], and returns a Future that completes to the
-  /// body of the response as a String.
-  ///
-  /// The Future will emit a [ClientException] if the response doesn't have a
-  /// success status code.
-  ///
-  /// For more fine-grained control over the request and response, use [send] or
-  /// [get] instead.
   Future<String> read(url, {Map<String, String> headers}) async {
     var response = await get(url, headers: headers);
     _checkResponseSuccess(url, response);
@@ -123,15 +46,6 @@ abstract class BaseClient implements Client {
     return await response.readAsString();
   }
 
-  /// Sends an HTTP GET request with the given headers to the given URL, which
-  /// can be a [Uri] or a [String], and returns a Future that completes to the
-  /// body of the response as a list of bytes.
-  ///
-  /// The Future will emit an [ClientException] if the response doesn't have a
-  /// success status code.
-  ///
-  /// For more fine-grained control over the request and response, use [send] or
-  /// [get] instead.
   Future<Uint8List> readBytes(url, {Map<String, String> headers}) async {
     var response = await get(url, headers: headers);
     _checkResponseSuccess(url, response);
@@ -139,28 +53,17 @@ abstract class BaseClient implements Client {
     return await collectBytes(response.read());
   }
 
-  /// Sends an HTTP request and asynchronously returns the response.
-  ///
-  /// Implementers should call [BaseRequest.finalize] to get the body of the
-  /// request as a [ByteStream]. They shouldn't make any assumptions about the
-  /// state of the stream; it could have data written to it asynchronously at a
-  /// later point, or it could already be closed when it's returned. Any
-  /// internal HTTP errors should be wrapped as [ClientException]s.
   Future<Response> send(Request request);
 
-  /// Throws an error if [response] is not successful.
-  void _checkResponseSuccess(url, Response response) {
-    if (response.statusCode < 400) return;
-    var message = "Request to $url failed with status ${response.statusCode}";
-    if (response.reasonPhrase != null) {
-      message = "$message: ${response.reasonPhrase}";
-    }
-    if (url is String) url = Uri.parse(url);
-    throw new ClientException("$message.", url);
-  }
-
-  /// Closes the client and cleans up any resources associated with it. It's
-  /// important to close each client when it's done being used; failing to do so
-  /// can cause the Dart process to hang.
   void close() {}
+
+  /// Throws an error if [response] is not successful.
+  static void _checkResponseSuccess(url, Response response) {
+    if (response.statusCode >= 400) {
+      throw new ClientException(
+          'Request to $url failed with status ${response.statusCode}: '
+              '${response.reasonPhrase}',
+          getUrl(url));
+    }
+  }
 }

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -36,8 +36,8 @@ abstract class Client {
   /// [Future<Response>]. It will be called when [Client.send] is invoked.
   ///
   /// When [Client.close] is called the [onClose] function will be called.
-  factory Client.handler(Handler handler, {void onClose()})
-      => new HandlerClient(handler, onClose ?? () {});
+  factory Client.handler(Handler handler, {void onClose()}) =>
+      new HandlerClient(handler, onClose ?? () {});
 
   /// Sends an HTTP HEAD request with the given headers to the given URL, which
   /// can be a [Uri] or a [String].
@@ -69,8 +69,8 @@ abstract class Client {
   /// [encoding] defaults to [UTF8].
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> post(url, body, {Map<String, String> headers,
-      Encoding encoding});
+  Future<Response> post(url, body,
+      {Map<String, String> headers, Encoding encoding});
 
   /// Sends an HTTP PUT request with the given headers and body to the given
   /// URL, which can be a [Uri] or a [String].
@@ -90,8 +90,8 @@ abstract class Client {
   /// [encoding] defaults to [UTF8].
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> put(url, body, {Map<String, String> headers,
-      Encoding encoding});
+  Future<Response> put(url, body,
+      {Map<String, String> headers, Encoding encoding});
 
   /// Sends an HTTP PATCH request with the given headers and body to the given
   /// URL, which can be a [Uri] or a [String].
@@ -111,8 +111,8 @@ abstract class Client {
   /// [encoding] defaults to [UTF8].
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> patch(url, body, {Map<String, String> headers,
-      Encoding encoding});
+  Future<Response> patch(url, body,
+      {Map<String, String> headers, Encoding encoding});
 
   /// Sends an HTTP DELETE request with the given headers to the given URL,
   /// which can be a [Uri] or a [String].
@@ -145,8 +145,9 @@ abstract class Client {
   /// Sends an HTTP request and asynchronously returns the response.
   Future<Response> send(Request request);
 
-  /// Closes the client and cleans up any resources associated with it. It's
-  /// important to close each client when it's done being used; failing to do so
-  /// can cause the Dart process to hang.
+  /// Closes the client and cleans up any resources associated with it.
+  ///
+  /// It's important to close each client when it's done being used; failing to
+  /// do so can cause the Dart process to hang.
   void close();
 }

--- a/lib/src/handler_client.dart
+++ b/lib/src/handler_client.dart
@@ -18,13 +18,10 @@ class HandlerClient extends BaseClient {
   final void Function() _close;
 
   /// Creates a new client using the [_handler] and [onClose] functions.
-  HandlerClient(this._handler, void onClose())
-      : _close = onClose;
+  HandlerClient(this._handler, void onClose()) : _close = onClose;
 
-  /// Sends an HTTP request and asynchronously returns the response.
   Future<Response> send(Request request) => _handler(request);
 
-  /// Closes the client and cleans up any resources associated with it.
   void close() {
     _close();
   }

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -29,9 +29,9 @@ class IOClient extends BaseClient {
       var context = request.context;
 
       ioRequest
-          ..followRedirects = context['io.followRedirects'] ?? true
-          ..maxRedirects = context['io.maxRedirects'] ?? 5
-          ..persistentConnection = context['io.persistentConnection'] ?? true;
+        ..followRedirects = context['io.followRedirects'] ?? true
+        ..maxRedirects = context['io.maxRedirects'] ?? 5
+        ..persistentConnection = context['io.persistentConnection'] ?? true;
       request.headers.forEach((name, value) {
         ioRequest.headers.set(name, value);
       });
@@ -44,9 +44,7 @@ class IOClient extends BaseClient {
         headers[key] = values.join(',');
       });
 
-      return new Response(
-          _responseUrl(request, response),
-          response.statusCode,
+      return new Response(_responseUrl(request, response), response.statusCode,
           reasonPhrase: response.reasonPhrase,
           body: DelegatingStream.typed<List<int>>(response).handleError(
               (error) => throw new ClientException(error.message, error.uri),

--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -40,19 +40,16 @@ typedef Client Middleware(Client inner);
 /// If provided, [errorHandler] receives errors thrown by the inner handler. It
 /// does not receive errors thrown by [requestHandler] or [responseHandler].
 /// It can either return a new response or throw an error.
-Middleware createMiddleware({
-  Future<Request> requestHandler(Request request),
-  Future<Response> responseHandler(Response response),
-  void onClose(),
-  void errorHandler(error, [StackTrace stackTrace])
-}) {
+Middleware createMiddleware(
+    {Future<Request> requestHandler(Request request),
+    Future<Response> responseHandler(Response response),
+    void onClose(),
+    void errorHandler(error, [StackTrace stackTrace])}) {
   requestHandler ??= (request) async => request;
   responseHandler ??= (response) async => response;
 
-  return (inner) {
-    return new HandlerClient(
-      (request) =>
-        requestHandler(request)
+  return (inner) => new HandlerClient(
+        (request) => requestHandler(request)
             .then((req) => inner.send(req))
             .then((res) => responseHandler(res), onError: errorHandler),
         onClose == null
@@ -61,6 +58,5 @@ Middleware createMiddleware({
                 onClose();
                 inner.close();
               },
-    );
-  };
+      );
 }

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -42,10 +42,13 @@ class Response extends Message {
       Encoding encoding,
       Map<String, String> headers,
       Map<String, Object> context})
-      : this._(getUrl(finalUrl), statusCode, reasonPhrase ?? '',
-      body, encoding, headers, context);
+      : this._(getUrl(finalUrl), statusCode, reasonPhrase ?? '', body, encoding,
+            headers, context);
 
-  Response._(this.finalUrl, this.statusCode, this.reasonPhrase,
+  Response._(
+      this.finalUrl,
+      this.statusCode,
+      this.reasonPhrase,
       body,
       Encoding encoding,
       Map<String, String> headers,
@@ -68,20 +71,12 @@ class Response extends Message {
   /// [body] is the request body. It may be either a [String], a [List<int>], a
   /// [Stream<List<int>>], or `null` to indicate no body.
   Response change(
-      {Map<String, String> headers,
-      Map<String, Object> context,
-      body}) {
+      {Map<String, String> headers, Map<String, Object> context, body}) {
     var updatedHeaders = updateMap(this.headers, headers);
     var updatedContext = updateMap(this.context, context);
 
-    return new Response._(
-        this.finalUrl,
-        this.statusCode,
-        this.reasonPhrase,
-        body ?? getBody(this),
-        this.encoding,
-        updatedHeaders,
-        updatedContext);
+    return new Response._(finalUrl, statusCode, reasonPhrase,
+        body ?? getBody(this), encoding, updatedHeaders, updatedContext);
   }
 
   /// The date and time after which the response's data should be considered
@@ -95,6 +90,7 @@ class Response extends Message {
     _expiresCache = parseHttpDate(headers['expires']);
     return _expiresCache;
   }
+
   DateTime _expiresCache;
 
   /// The date and time the source of the response's data was last modified.
@@ -107,5 +103,6 @@ class Response extends Message {
     _lastModifiedCache = parseHttpDate(headers['last-modified']);
     return _lastModifiedCache;
   }
+
   DateTime _lastModifiedCache;
 }

--- a/test/hybrid/server.dart
+++ b/test/hybrid/server.dart
@@ -7,7 +7,7 @@ import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:http/src/content_type.dart';
-import "package:stream_channel/stream_channel.dart";
+import 'package:stream_channel/stream_channel.dart';
 
 /// The list of headers to ignore when sending back confirmation.
 final _ignoreHeaders = <String>[
@@ -57,35 +57,39 @@ hybridMain(StreamChannel channel) async {
     var response = request.response;
 
     if (path == '/error') {
-      response.statusCode = 400;
-      response.contentLength = 0;
-      response.close();
+      response
+        ..statusCode = 400
+        ..contentLength = 0
+        ..close();
       return;
     }
 
     if (path == '/loop') {
       var n = int.parse(request.uri.query);
-      response.statusCode = 302;
-      response.headers
-          .set('location', serverUrl.resolve('/loop?${n + 1}').toString());
-      response.contentLength = 0;
-      response.close();
+      response
+        ..statusCode = 302
+        ..headers
+            .set('location', serverUrl.resolve('/loop?${n + 1}').toString())
+        ..contentLength = 0
+        ..close();
       return;
     }
 
     if (path == '/redirect') {
-      response.statusCode = 302;
-      response.headers.set('location', serverUrl.resolve('/').toString());
-      response.contentLength = 0;
-      response.close();
+      response
+        ..statusCode = 302
+        ..headers.set('location', serverUrl.resolve('/').toString())
+        ..contentLength = 0
+        ..close();
       return;
     }
 
     if (path == '/no-content-length') {
-      response.statusCode = 200;
-      response.contentLength = -1;
-      response.write('body');
-      response.close();
+      response
+        ..statusCode = 200
+        ..contentLength = -1
+        ..write('body')
+        ..close();
       return;
     }
 
@@ -99,7 +103,7 @@ hybridMain(StreamChannel channel) async {
       }
 
       response.headers.contentType =
-          new ContentType("application", "json", charset: outputEncoding.name);
+          new ContentType('application', 'json', charset: outputEncoding.name);
 
       // Add CORS headers for browser testing
       response.headers.set('access-control-allow-origin', '*');
@@ -113,8 +117,7 @@ hybridMain(StreamChannel channel) async {
         requestBody = null;
       } else if (request.headers.contentType != null &&
           request.headers.contentType.charset != null) {
-        var encoding =
-            encodingForCharset(request.headers.contentType.charset);
+        var encoding = encodingForCharset(request.headers.contentType.charset);
         requestBody = encoding.decode(requestBodyBytes);
       } else {
         requestBody = requestBodyBytes;
@@ -134,9 +137,11 @@ hybridMain(StreamChannel channel) async {
       });
 
       var body = JSON.encode(content);
-      response.contentLength = body.length;
-      response.write(body);
-      response.close();
+
+      response
+        ..contentLength = body.length
+        ..write(body)
+        ..close();
     });
   });
 

--- a/test/message_change_test.dart
+++ b/test/message_change_test.dart
@@ -14,17 +14,13 @@ final _uri = Uri.parse('http://localhost/');
 
 void main() {
   group('Request', () {
-    _testChange(({body, headers, context}) {
-      return new Request('GET', _uri,
-          body: body, headers: headers, context: context);
-    });
+    _testChange(({body, headers, context}) => new Request('GET', _uri,
+        body: body, headers: headers, context: context));
   });
 
   group('Response', () {
-    _testChange(({body, headers, context}) {
-      return new Response(_uri, 200,
-          body: body, headers: headers, context: context);
-    });
+    _testChange(({body, headers, context}) => new Response(_uri, 200,
+        body: body, headers: headers, context: context));
   });
 }
 

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 import 'package:http/src/message.dart';
 
 // "hello,"
-const HELLO_BYTES = const [104, 101, 108, 108, 111, 44];
+const _helloBytes = const [104, 101, 108, 108, 111, 44];
 
 // " world"
-const WORLD_BYTES = const [32, 119, 111, 114, 108, 100];
+const _worldBytes = const [32, 119, 111, 114, 108, 100];
 
 class _TestMessage extends Message {
   _TestMessage(Map<String, String> headers, Map<String, Object> context, body,
@@ -27,12 +27,11 @@ class _TestMessage extends Message {
 }
 
 Message _createMessage(
-    {Map<String, String> headers,
-    Map<String, Object> context,
-    body,
-    Encoding encoding}) {
-  return new _TestMessage(headers, context, body, encoding);
-}
+        {Map<String, String> headers,
+        Map<String, Object> context,
+        body,
+        Encoding encoding}) =>
+    new _TestMessage(headers, context, body, encoding);
 
 void main() {
   group('headers', () {
@@ -78,78 +77,78 @@ void main() {
     });
   });
 
-  group("readAsString", () {
-    test("supports a null body", () {
+  group('readAsString', () {
+    test('supports a null body', () {
       var request = _createMessage();
-      expect(request.readAsString(), completion(equals("")));
+      expect(request.readAsString(), completion(equals('')));
     });
 
-    test("supports a Stream<List<int>> body", () {
+    test('supports a Stream<List<int>> body', () {
       var controller = new StreamController();
       var request = _createMessage(body: controller.stream);
-      expect(request.readAsString(), completion(equals("hello, world")));
+      expect(request.readAsString(), completion(equals('hello, world')));
 
-      controller.add(HELLO_BYTES);
+      controller.add(_helloBytes);
       return new Future(() {
         controller
-          ..add(WORLD_BYTES)
+          ..add(_worldBytes)
           ..close();
       });
     });
 
-    test("defaults to UTF-8", () {
+    test('defaults to UTF-8', () {
       var request = _createMessage(
           body: new Stream.fromIterable([
         [195, 168]
       ]));
-      expect(request.readAsString(), completion(equals("è")));
+      expect(request.readAsString(), completion(equals('è')));
     });
 
-    test("the content-type header overrides the default", () {
+    test('the content-type header overrides the default', () {
       var request = _createMessage(
           headers: {'content-type': 'text/plain; charset=iso-8859-1'},
           body: new Stream.fromIterable([
             [195, 168]
           ]));
-      expect(request.readAsString(), completion(equals("Ã¨")));
+      expect(request.readAsString(), completion(equals('Ã¨')));
     });
 
-    test("an explicit encoding overrides the content-type header", () {
+    test('an explicit encoding overrides the content-type header', () {
       var request = _createMessage(
           headers: {'content-type': 'text/plain; charset=iso-8859-1'},
           body: new Stream.fromIterable([
             [195, 168]
           ]));
-      expect(request.readAsString(LATIN1), completion(equals("Ã¨")));
+      expect(request.readAsString(LATIN1), completion(equals('Ã¨')));
     });
   });
 
-  group("read", () {
-    test("supports a null body", () {
+  group('read', () {
+    test('supports a null body', () {
       var request = _createMessage();
       expect(request.read().toList(), completion(isEmpty));
     });
 
-    test("supports a Stream<List<int>> body", () {
+    test('supports a Stream<List<int>> body', () {
       var controller = new StreamController();
       var request = _createMessage(body: controller.stream);
       expect(request.read().toList(),
-          completion(equals([HELLO_BYTES, WORLD_BYTES])));
+          completion(equals([_helloBytes, _worldBytes])));
 
-      controller.add(HELLO_BYTES);
+      controller.add(_helloBytes);
       return new Future(() {
         controller
-          ..add(WORLD_BYTES)
+          ..add(_worldBytes)
           ..close();
       });
     });
 
-    test("supports a List<int> body", () {
-      var request = _createMessage(body: HELLO_BYTES);
-      expect(request.read().toList(), completion(equals([HELLO_BYTES])));
+    test('supports a List<int> body', () {
+      var request = _createMessage(body: _helloBytes);
+      expect(request.read().toList(), completion(equals([_helloBytes])));
     });
 
-    test("throws when calling read()/readAsString() multiple times", () {
+    test('throws when calling read()/readAsString() multiple times', () {
       var request;
 
       request = _createMessage();
@@ -170,25 +169,25 @@ void main() {
     });
   });
 
-  group("content-length", () {
-    test("is null with a default body and without a content-length header", () {
+  group('content-length', () {
+    test('is null with a default body and without a content-length header', () {
       var request = _createMessage();
       expect(request.contentLength, isNull);
     });
 
-    test("comes from a byte body", () {
+    test('comes from a byte body', () {
       var request = _createMessage(body: [1, 2, 3]);
       expect(request.contentLength, 3);
       expect(request.isEmpty, isFalse);
     });
 
-    test("comes from a string body", () {
+    test('comes from a string body', () {
       var request = _createMessage(body: 'foobar');
       expect(request.contentLength, 6);
       expect(request.isEmpty, isFalse);
     });
 
-    test("is set based on byte length for a string body", () {
+    test('is set based on byte length for a string body', () {
       var request = _createMessage(body: 'fööbär');
       expect(request.contentLength, 9);
       expect(request.isEmpty, isFalse);
@@ -198,51 +197,52 @@ void main() {
       expect(request.isEmpty, isFalse);
     });
 
-    test("is null for a stream body", () {
-      var request = _createMessage(body: new Stream.empty());
+    test('is null for a stream body', () {
+      var request = _createMessage(body: const Stream<List<int>>.empty());
       expect(request.contentLength, isNull);
     });
 
-    test("uses the content-length header for a stream body", () {
+    test('uses the content-length header for a stream body', () {
       var request = _createMessage(
-          body: new Stream.empty(), headers: {'content-length': '42'});
+          body: const Stream<List<int>>.empty(),
+          headers: {'content-length': '42'});
       expect(request.contentLength, 42);
       expect(request.isEmpty, isFalse);
     });
 
-    test("real body length takes precedence over content-length header", () {
+    test('real body length takes precedence over content-length header', () {
       var request =
           _createMessage(body: [1, 2, 3], headers: {'content-length': '42'});
       expect(request.contentLength, 3);
       expect(request.isEmpty, isFalse);
     });
 
-    test("is null for a chunked transfer encoding", () {
+    test('is null for a chunked transfer encoding', () {
       var request = _createMessage(
-          body: "1\r\na0\r\n\r\n", headers: {'transfer-encoding': 'chunked'});
+          body: '1\r\na0\r\n\r\n', headers: {'transfer-encoding': 'chunked'});
       expect(request.contentLength, isNull);
     });
 
-    test("is null for a non-identity transfer encoding", () {
+    test('is null for a non-identity transfer encoding', () {
       var request = _createMessage(
-          body: "1\r\na0\r\n\r\n", headers: {'transfer-encoding': 'custom'});
+          body: '1\r\na0\r\n\r\n', headers: {'transfer-encoding': 'custom'});
       expect(request.contentLength, isNull);
     });
 
-    test("is set for identity transfer encoding", () {
+    test('is set for identity transfer encoding', () {
       var request = _createMessage(
-          body: "1\r\na0\r\n\r\n", headers: {'transfer-encoding': 'identity'});
+          body: '1\r\na0\r\n\r\n', headers: {'transfer-encoding': 'identity'});
       expect(request.contentLength, equals(9));
       expect(request.isEmpty, isFalse);
     });
   });
 
-  group("mimeType", () {
-    test("is null without a content-type header", () {
+  group('mimeType', () {
+    test('is null without a content-type header', () {
       expect(_createMessage().mimeType, isNull);
     });
 
-    test("comes from the content-type header", () {
+    test('comes from the content-type header', () {
       expect(_createMessage(headers: {'content-type': 'text/plain'}).mimeType,
           equals('text/plain'));
     });
@@ -256,24 +256,24 @@ void main() {
     });
   });
 
-  group("encoding", () {
-    test("is null without a content-type header", () {
+  group('encoding', () {
+    test('is null without a content-type header', () {
       expect(_createMessage().encoding, isNull);
     });
 
-    test("is null without a charset parameter", () {
+    test('is null without a charset parameter', () {
       expect(_createMessage(headers: {'content-type': 'text/plain'}).encoding,
           isNull);
     });
 
-    test("is null with an unrecognized charset parameter", () {
+    test('is null with an unrecognized charset parameter', () {
       expect(
           _createMessage(
               headers: {'content-type': 'text/plain; charset=fblthp'}).encoding,
           isNull);
     });
 
-    test("comes from the content-type charset parameter", () {
+    test('comes from the content-type charset parameter', () {
       expect(
           _createMessage(
                   headers: {'content-type': 'text/plain; charset=iso-8859-1'})
@@ -281,7 +281,7 @@ void main() {
           equals(LATIN1));
     });
 
-    test("comes from the content-type charset parameter with a different case",
+    test('comes from the content-type charset parameter with a different case',
         () {
       expect(
           _createMessage(
@@ -290,50 +290,50 @@ void main() {
           equals(LATIN1));
     });
 
-    test("defaults to encoding a String as UTF-8", () {
+    test('defaults to encoding a String as UTF-8', () {
       expect(
-          _createMessage(body: "è").read().toList(),
+          _createMessage(body: 'è').read().toList(),
           completion(equals([
             [195, 168]
           ])));
     });
 
-    test("uses the explicit encoding if available", () {
+    test('uses the explicit encoding if available', () {
       expect(
-          _createMessage(body: "è", encoding: LATIN1).read().toList(),
+          _createMessage(body: 'è', encoding: LATIN1).read().toList(),
           completion(equals([
             [232]
           ])));
     });
 
-    test("adds an explicit encoding to the content-type", () {
+    test('adds an explicit encoding to the content-type', () {
       var request = _createMessage(
-          body: "è", encoding: LATIN1, headers: {'content-type': 'text/plain'});
+          body: 'è', encoding: LATIN1, headers: {'content-type': 'text/plain'});
       expect(request.headers,
           containsPair('content-type', 'text/plain; charset=iso-8859-1'));
     });
 
-    test("adds an explicit encoding to the content-type with a different case",
+    test('adds an explicit encoding to the content-type with a different case',
         () {
       var request = _createMessage(
-          body: "è", encoding: LATIN1, headers: {'Content-Type': 'text/plain'});
+          body: 'è', encoding: LATIN1, headers: {'Content-Type': 'text/plain'});
       expect(request.headers,
           containsPair('Content-Type', 'text/plain; charset=iso-8859-1'));
     });
 
     test(
-        "sets an absent content-type to application/octet-stream in order to "
-        "set the charset", () {
-      var request = _createMessage(body: "è", encoding: LATIN1);
+        'sets an absent content-type to application/octet-stream in order to '
+        'set the charset', () {
+      var request = _createMessage(body: 'è', encoding: LATIN1);
       expect(
           request.headers,
           containsPair(
               'content-type', 'application/octet-stream; charset=iso-8859-1'));
     });
 
-    test("overwrites an existing charset if given an explicit encoding", () {
+    test('overwrites an existing charset if given an explicit encoding', () {
       var request = _createMessage(
-          body: "è",
+          body: 'è',
           encoding: LATIN1,
           headers: {'content-type': 'text/plain; charset=whatever'});
       expect(request.headers,

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -46,7 +46,7 @@ void main() {
   });
 
   test('Pipeline can be used as middleware', () async {
-    int accessLocation = 0;
+    var accessLocation = 0;
 
     var middlewareA = createMiddleware(requestHandler: (request) async {
       expect(accessLocation, 0);
@@ -86,7 +86,7 @@ void main() {
   });
 
   test('Pipeline calls close on all middleware', () {
-    int accessLocation = 0;
+    var accessLocation = 0;
 
     var middlewareA = createMiddleware(onClose: () {
       expect(accessLocation, 0);
@@ -98,15 +98,15 @@ void main() {
       accessLocation = 2;
     });
 
-    var client = const Pipeline()
+    const Pipeline()
         .addMiddleware(middlewareA)
         .addMiddleware(middlewareB)
         .addClient(new Client.handler((request) async => null, onClose: () {
           expect(accessLocation, 2);
           accessLocation = 3;
-        }));
+        }))
+          ..close();
 
-    client.close();
     expect(accessLocation, 3);
   });
 }

--- a/test/request_test.dart
+++ b/test/request_test.dart
@@ -68,7 +68,7 @@ void main() {
 
     test('is encoded according to the given encoding', () {
       var request =
-          new http.Request('POST', dummyUrl, encoding: LATIN1, body: "föøbãr");
+          new http.Request('POST', dummyUrl, encoding: LATIN1, body: 'föøbãr');
       expect(collectBytes(request.read()),
           completion(equals([102, 246, 248, 98, 227, 114])));
     });
@@ -76,7 +76,7 @@ void main() {
     test('is decoded according to the given encoding', () {
       var request = new http.Request('POST', dummyUrl,
           encoding: LATIN1, body: [102, 246, 248, 98, 227, 114]);
-      expect(request.readAsString(), completion(equals("föøbãr")));
+      expect(request.readAsString(), completion(equals('föøbãr')));
     });
   });
 
@@ -85,7 +85,7 @@ void main() {
       var request = new http.Request('POST', dummyUrl,
           headers: {'Content-Type': 'application/x-www-form-urlencoded'},
           encoding: LATIN1,
-          body: {"föø": "bãr"});
+          body: {'föø': 'bãr'});
       expect(request.readAsString(), completion(equals('f%F6%F8=b%E3r')));
     });
   });
@@ -157,7 +157,7 @@ void main() {
           equals('application/json; charset=iso-8859-1'));
     });
 
-    test("doen't have its charset overridden by setting bodyFields", () {
+    test("doesn't have its charset overridden by setting bodyFields", () {
       var request = new http.Request('POST', dummyUrl, headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=iso-8859-1'
       }, body: {
@@ -167,7 +167,7 @@ void main() {
           equals('application/x-www-form-urlencoded; charset=iso-8859-1'));
     });
 
-    test("doen't have its charset overridden by setting body", () {
+    test("doesn't have its charset overridden by setting body", () {
       var request = new http.Request('POST', dummyUrl,
           headers: {'Content-Type': 'application/json; charset=iso-8859-1'},
           body: '{"hello": "world"}');
@@ -192,7 +192,7 @@ void main() {
       expect(copy.readAsString(), completion('hello, world'));
     });
 
-    test("allows the original request to be read", () {
+    test('allows the original request to be read', () {
       var request = new http.Request('GET', dummyUrl);
       var changed = request.change();
 
@@ -200,7 +200,7 @@ void main() {
       expect(changed.read, throwsStateError);
     });
 
-    test("allows the changed request to be read", () {
+    test('allows the changed request to be read', () {
       var request = new http.Request('GET', dummyUrl);
       var changed = request.change();
 
@@ -208,7 +208,7 @@ void main() {
       expect(request.read, throwsStateError);
     });
 
-    test("allows another changed request to be read", () {
+    test('allows another changed request to be read', () {
       var request = new http.Request('GET', dummyUrl);
       var changed1 = request.change();
       var changed2 = request.change();


### PR DESCRIPTION
Do some cleanup

* dartfmt all the things
* Use `'` not `"`
* Remove docs for overridden members
* Use method cascades when possible
* Fix up some documentation that was incorrect