### PR TITLE
Handle onAbort within BrowserClient

### DIFF
--- a/lib/browser_client.dart
+++ b/lib/browser_client.dart
@@ -73,6 +73,7 @@ class BrowserClient extends BaseClient {
           StackTrace.current);
     });
 
+    // Catch the abort event so futures complete when close is called.
     xhr.onAbort.first.then((_) {
       completer.completeError(
           new ClientException('Request cancelled', request.url),

--- a/lib/browser_client.dart
+++ b/lib/browser_client.dart
@@ -73,6 +73,12 @@ class BrowserClient extends BaseClient {
           StackTrace.current);
     });
 
+    xhr.onAbort.first.then((_) {
+      completer.completeError(
+          new ClientException('Request cancelled', request.url),
+          StackTrace.current);
+    });
+
     xhr.send(bytes);
 
     try {


### PR DESCRIPTION
`BrowserClient.close` calls `abort()` on the `HttpRequest`. Make sure that the client receives an error.