### PR TITLE
Cleanup library code

### DIFF
--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -61,10 +61,10 @@ abstract class BaseClient implements Client {
   /// Throws an error if [response] is not successful.
   static void _checkResponseSuccess(url, Response response) {
     if (response.statusCode < 400) return;
-    var message = 'Request to $url failed with status ${response.statusCode}';
+    var message = "Request to $url failed with status ${response.statusCode}";
     if (response.reasonPhrase.isNotEmpty) {
-      message = '$message: ${response.reasonPhrase}';
+      message = "$message: ${response.reasonPhrase}";
     }
-    throw new ClientException('$message.', getUrl(url));
+    throw new ClientException("$message.", getUrl(url));
   }
 }

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -59,7 +59,7 @@ abstract class BaseClient implements Client {
   void close() {}
 
   /// Throws an error if [response] is not successful.
-  static void _checkResponseSuccess(url, Response response) {
+  void _checkResponseSuccess(url, Response response) {
     if (response.statusCode < 400) return;
     var message = "Request to $url failed with status ${response.statusCode}";
     if (response.reasonPhrase.isNotEmpty) {

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -12,6 +12,7 @@ import 'client.dart';
 import 'exception.dart';
 import 'request.dart';
 import 'response.dart';
+import 'utils.dart';
 
 /// The abstract base class for an HTTP client.
 ///
@@ -55,16 +56,15 @@ abstract class BaseClient implements Client {
 
   Future<Response> send(Request request);
 
-  /// Throws an error if [response] is not successful.
-  void _checkResponseSuccess(url, Response response) {
-    if (response.statusCode < 400) return;
-    var message = "Request to $url failed with status ${response.statusCode}";
-    if (response.reasonPhrase != null) {
-      message = "$message: ${response.reasonPhrase}";
-    }
-    if (url is String) url = Uri.parse(url);
-    throw new ClientException("$message.", url);
-  }
-
   void close() {}
+
+  /// Throws an error if [response] is not successful.
+  static void _checkResponseSuccess(url, Response response) {
+    if (response.statusCode < 400) return;
+    var message = 'Request to $url failed with status ${response.statusCode}';
+    if (response.reasonPhrase.isNotEmpty) {
+      message = '$message: ${response.reasonPhrase}';
+    }
+    throw new ClientException('$message.', getUrl(url));
+  }
 }

--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -48,17 +48,15 @@ Middleware createMiddleware(
   requestHandler ??= (request) async => request;
   responseHandler ??= (response) async => response;
 
-  return (inner) {
-    return new HandlerClient(
-      (request) => requestHandler(request)
-          .then((req) => inner.send(req))
-          .then((res) => responseHandler(res), onError: errorHandler),
-      onClose == null
-          ? inner.close
-          : () {
-              onClose();
-              inner.close();
-            },
-    );
-  };
+  return (inner) => new HandlerClient(
+        (request) => requestHandler(request)
+            .then((req) => inner.send(req))
+            .then((res) => responseHandler(res), onError: errorHandler),
+        onClose == null
+            ? inner.close
+            : () {
+                onClose();
+                inner.close();
+              },
+      );
 }

--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -48,7 +48,8 @@ Middleware createMiddleware(
   requestHandler ??= (request) async => request;
   responseHandler ??= (response) async => response;
 
-  return (inner) => new HandlerClient(
+  return (inner) {
+    return new HandlerClient(
         (request) => requestHandler(request)
             .then((req) => inner.send(req))
             .then((res) => responseHandler(res), onError: errorHandler),
@@ -57,6 +58,6 @@ Middleware createMiddleware(
             : () {
                 onClose();
                 inner.close();
-              },
-      );
+              });
+  };
 }

--- a/lib/src/multipart_file.dart
+++ b/lib/src/multipart_file.dart
@@ -9,8 +9,6 @@ import 'package:async/async.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:mime/mime.dart';
 
-import 'content_type.dart';
-
 /// A file to be uploaded as part of a `multipart/form-data` Request.
 ///
 /// This doesn't need to correspond to a physical file.

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -187,7 +187,7 @@ class Request extends Message {
     var updatedHeaders = updateMap(this.headers, headers);
     var updatedContext = updateMap(this.context, context);
 
-    return new Request._(this.method, this.url, body ?? getBody(this),
-        this.encoding, updatedHeaders, updatedContext);
+    return new Request._(method, url, body ?? getBody(this), encoding,
+        updatedHeaders, updatedContext);
   }
 }

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -75,8 +75,8 @@ class Response extends Message {
     var updatedHeaders = updateMap(this.headers, headers);
     var updatedContext = updateMap(this.context, context);
 
-    return new Response._(this.finalUrl, this.statusCode, this.reasonPhrase,
-        body ?? getBody(this), this.encoding, updatedHeaders, updatedContext);
+    return new Response._(finalUrl, statusCode, reasonPhrase,
+        body ?? getBody(this), encoding, updatedHeaders, updatedContext);
   }
 
   /// The date and time after which the response's data should be considered

--- a/test/hybrid/server.dart
+++ b/test/hybrid/server.dart
@@ -57,35 +57,39 @@ hybridMain(StreamChannel channel) async {
     var response = request.response;
 
     if (path == '/error') {
-      response.statusCode = 400;
-      response.contentLength = 0;
-      response.close();
+      response
+        ..statusCode = 400
+        ..contentLength = 0
+        ..close();
       return;
     }
 
     if (path == '/loop') {
       var n = int.parse(request.uri.query);
-      response.statusCode = 302;
-      response.headers
-          .set('location', serverUrl.resolve('/loop?${n + 1}').toString());
-      response.contentLength = 0;
-      response.close();
+      response
+        ..statusCode = 302
+        ..headers
+            .set('location', serverUrl.resolve('/loop?${n + 1}').toString())
+        ..contentLength = 0
+        ..close();
       return;
     }
 
     if (path == '/redirect') {
-      response.statusCode = 302;
-      response.headers.set('location', serverUrl.resolve('/').toString());
-      response.contentLength = 0;
-      response.close();
+      response
+        ..statusCode = 302
+        ..headers.set('location', serverUrl.resolve('/').toString())
+        ..contentLength = 0
+        ..close();
       return;
     }
 
     if (path == '/no-content-length') {
-      response.statusCode = 200;
-      response.contentLength = -1;
-      response.write('body');
-      response.close();
+      response
+        ..statusCode = 200
+        ..contentLength = -1
+        ..write('body')
+        ..close();
       return;
     }
 
@@ -133,9 +137,10 @@ hybridMain(StreamChannel channel) async {
       });
 
       var body = JSON.encode(content);
-      response.contentLength = body.length;
-      response.write(body);
-      response.close();
+      response
+        ..contentLength = body.length
+        ..write(body)
+        ..close();
     });
   });
 

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -10,10 +10,10 @@ import 'package:test/test.dart';
 import 'package:http/src/message.dart';
 
 // "hello,"
-const HELLO_BYTES = const [104, 101, 108, 108, 111, 44];
+const _helloBytes = const [104, 101, 108, 108, 111, 44];
 
 // " world"
-const WORLD_BYTES = const [32, 119, 111, 114, 108, 100];
+const _worldBytes = const [32, 119, 111, 114, 108, 100];
 
 class _TestMessage extends Message {
   _TestMessage(Map<String, String> headers, Map<String, Object> context, body,
@@ -27,12 +27,11 @@ class _TestMessage extends Message {
 }
 
 Message _createMessage(
-    {Map<String, String> headers,
-    Map<String, Object> context,
-    body,
-    Encoding encoding}) {
-  return new _TestMessage(headers, context, body, encoding);
-}
+        {Map<String, String> headers,
+        Map<String, Object> context,
+        body,
+        Encoding encoding}) =>
+    new _TestMessage(headers, context, body, encoding);
 
 void main() {
   group('headers', () {
@@ -89,10 +88,10 @@ void main() {
       var request = _createMessage(body: controller.stream);
       expect(request.readAsString(), completion(equals("hello, world")));
 
-      controller.add(HELLO_BYTES);
+      controller.add(_helloBytes);
       return new Future(() {
         controller
-          ..add(WORLD_BYTES)
+          ..add(_worldBytes)
           ..close();
       });
     });
@@ -134,19 +133,19 @@ void main() {
       var controller = new StreamController();
       var request = _createMessage(body: controller.stream);
       expect(request.read().toList(),
-          completion(equals([HELLO_BYTES, WORLD_BYTES])));
+          completion(equals([_helloBytes, _worldBytes])));
 
-      controller.add(HELLO_BYTES);
+      controller.add(_helloBytes);
       return new Future(() {
         controller
-          ..add(WORLD_BYTES)
+          ..add(_worldBytes)
           ..close();
       });
     });
 
     test("supports a List<int> body", () {
-      var request = _createMessage(body: HELLO_BYTES);
-      expect(request.read().toList(), completion(equals([HELLO_BYTES])));
+      var request = _createMessage(body: _helloBytes);
+      expect(request.read().toList(), completion(equals([_helloBytes])));
     });
 
     test("throws when calling read()/readAsString() multiple times", () {
@@ -199,13 +198,13 @@ void main() {
     });
 
     test("is null for a stream body", () {
-      var request = _createMessage(body: new Stream.empty());
+      var request = _createMessage(body: const Stream.empty());
       expect(request.contentLength, isNull);
     });
 
     test("uses the content-length header for a stream body", () {
       var request = _createMessage(
-          body: new Stream.empty(), headers: {'content-length': '42'});
+          body: const Stream.empty(), headers: {'content-length': '42'});
       expect(request.contentLength, 42);
       expect(request.isEmpty, isFalse);
     });

--- a/test/pipeline_test.dart
+++ b/test/pipeline_test.dart
@@ -46,7 +46,7 @@ void main() {
   });
 
   test('Pipeline can be used as middleware', () async {
-    int accessLocation = 0;
+    var accessLocation = 0;
 
     var middlewareA = createMiddleware(requestHandler: (request) async {
       expect(accessLocation, 0);
@@ -86,7 +86,7 @@ void main() {
   });
 
   test('Pipeline calls close on all middleware', () {
-    int accessLocation = 0;
+    var accessLocation = 0;
 
     var middlewareA = createMiddleware(onClose: () {
       expect(accessLocation, 0);
@@ -98,15 +98,15 @@ void main() {
       accessLocation = 2;
     });
 
-    var client = const Pipeline()
+    const Pipeline()
         .addMiddleware(middlewareA)
         .addMiddleware(middlewareB)
         .addClient(new Client.handler((request) async => null, onClose: () {
           expect(accessLocation, 2);
           accessLocation = 3;
-        }));
+        }))
+          ..close();
 
-    client.close();
     expect(accessLocation, 3);
   });
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -103,7 +103,7 @@ class _MultipartBodyMatches extends Matcher {
 ///
 /// [message] can be a String or a [Matcher].
 Matcher isClientException([message]) => predicate((error) {
-      expect(error, const isInstanceOf<http.ClientException>());
+      expect(error, new isInstanceOf<http.ClientException>());
       if (message != null) {
         expect(error.message, message);
       }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
@@ -61,11 +60,8 @@ class _Parse extends Matcher {
     return _matcher.matches(parsed, matchState);
   }
 
-  Description describe(Description description) {
-    return description
-        .add('parses to a value that ')
-        .addDescriptionOf(_matcher);
-  }
+  Description describe(Description description) =>
+      description.add('parses to a value that ').addDescriptionOf(_matcher);
 }
 
 /// A matcher that validates the body of a multipart request after finalization.
@@ -107,7 +103,7 @@ class _MultipartBodyMatches extends Matcher {
 ///
 /// [message] can be a String or a [Matcher].
 Matcher isClientException([message]) => predicate((error) {
-      expect(error, new isInstanceOf<http.ClientException>());
+      expect(error, const isInstanceOf<http.ClientException>());
       if (message != null) {
         expect(error.message, message);
       }


### PR DESCRIPTION
General cleanups like

* Use `=>` when possible
* Use `const` constructors when possible
* Remove unused imports
* Use method cascades
* Use `var`

Also makes `_checkResponseSuccess` use `getUrl` and check that the response text is not empty rather than null as `reasonPhrase` is never `null`