### PR TITLE
Add content type implicitly

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -63,7 +63,7 @@ abstract class Message {
       {Encoding encoding,
       Map<String, String> headers,
       Map<String, Object> context})
-      : this._(new Body(body, encoding), headers, context);
+      : this._(new Body(body, encoding), _addContentType(headers, body), context);
 
   Message._(Body body, Map<String, String> headers, Map<String, Object> context)
       : _body = body,
@@ -149,6 +149,28 @@ abstract class Message {
   /// changes.
   Message change(
       {Map<String, String> headers, Map<String, Object> context, body});
+}
+
+Map<String, String> _addContentType(Map<String, String> headers, body) {
+  var contentTypeHeader = getHeader(headers, 'content-type');
+
+  if (contentTypeHeader != null) return headers;
+
+  if (body is String) {
+    contentTypeHeader = 'text/plain; charset=utf-8';
+  } else if (body is Map) {
+    contentTypeHeader = 'application/x-www-form-urlencoded; charset=utf-8';
+  }
+
+  if (contentTypeHeader == null) return headers;
+
+  var newHeaders = headers == null
+      ? new CaseInsensitiveMap<String>()
+      : new CaseInsensitiveMap<String>.from(headers);
+
+  newHeaders['content-type'] = contentTypeHeader;
+
+  return newHeaders;
 }
 
 /// Adds information about encoding to [headers].

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -20,6 +20,11 @@ import 'utils.dart';
 /// for subclasses of [Message] but hidden elsewhere.
 Body getBody(Message message) => message._body;
 
+/// The default set of headers for a message created with no body and no
+/// explicit headers.
+final _defaultHeaders = new HttpUnmodifiableMap<String>({'content-length': '0'},
+    ignoreKeyCase: true);
+
 /// Represents logic shared between [Request] and [Response].
 abstract class Message {
   /// The HTTP headers.
@@ -63,7 +68,8 @@ abstract class Message {
       {Encoding encoding,
       Map<String, String> headers,
       Map<String, Object> context})
-      : this._(new Body(body, encoding), _addContentType(headers, body), context);
+      : this._(
+            new Body(body, encoding), _addContentType(headers, body), context);
 
   Message._(Body body, Map<String, String> headers, Map<String, Object> context)
       : _body = body,
@@ -152,6 +158,8 @@ abstract class Message {
 }
 
 Map<String, String> _addContentType(Map<String, String> headers, body) {
+  if (body == null) return headers;
+
   var contentTypeHeader = getHeader(headers, 'content-type');
 
   if (contentTypeHeader != null) return headers;
@@ -184,7 +192,7 @@ Map<String, String> _adjustHeaders(Map<String, String> headers, Body body) {
       return headers ?? const HttpUnmodifiableMap.empty();
     } else if (body.contentLength == 0 &&
         (headers == null || headers.isEmpty)) {
-      return const HttpUnmodifiableMap.empty();
+      return _defaultHeaders;
     }
   }
 

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -323,7 +323,7 @@ void main() {
     test(
         "sets an absent content-type to application/octet-stream in order to "
         "set the charset", () {
-      var request = _createMessage(body: "è", encoding: LATIN1);
+      var request = _createMessage(body: [232], encoding: LATIN1);
       expect(
           request.headers,
           containsPair(


### PR DESCRIPTION
This just adds a function that will attempt to add a content type based on the original body passed in.

All the logic in _adjustHeaders is kept the same it just appends an additional header if the body is a String or a Map.