### PR TITLE
Refactor adjustHeaders

### DIFF
--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -14,6 +14,15 @@ import 'content_type.dart';
 import 'http_unmodifiable_map.dart';
 import 'utils.dart';
 
+/// The default set of headers for a message created with no body and no
+/// explicit headers.
+final _defaultHeaders = new HttpUnmodifiableMap<String>({'content-length': '0'},
+    ignoreKeyCase: true);
+
+/// The default media type `application/octet-stream` as defined by HTTP.
+final MediaType _defaultMediaType =
+    new MediaType('application', 'octet-stream');
+
 /// Retrieves the [Body] contained in the [message].
 ///
 /// This is meant for internal use by `http` so the message body is accessible
@@ -150,12 +159,6 @@ abstract class Message {
   Message change(
       {Map<String, String> headers, Map<String, Object> context, body});
 
-  /// The default set of headers for a message created with no body and no
-  /// explicit headers.
-  static final _defaultHeaders = new HttpUnmodifiableMap<String>(
-      {'content-length': '0'},
-      ignoreKeyCase: true);
-
   /// Adds information about encoding and content-type to [headers].
   ///
   /// Returns a new map without modifying [headers].
@@ -172,18 +175,9 @@ abstract class Message {
       }
     }
 
-    var newHeaders = headers == null
-        ? new CaseInsensitiveMap<String>()
-        : new CaseInsensitiveMap<String>.from(headers);
-
-    if (contentType != null) {
-      newHeaders['content-type'] = contentType;
-    }
-
-    if (contentLength != null) {
-      newHeaders['content-length'] = contentLength;
-    }
-
+    var newHeaders = new CaseInsensitiveMap<String>.from(headers ?? const {});
+    if (contentType != null) newHeaders['content-type'] = contentType;
+    if (contentLength != null) newHeaders['content-length'] = contentLength;
     return newHeaders;
   }
 
@@ -196,19 +190,15 @@ abstract class Message {
     if (bodyLength == null) return null;
 
     var contentLengthHeader = bodyLength.toString();
-    if (contentLengthHeader == getHeader(headers, 'content-length'))
+    if (contentLengthHeader == getHeader(headers, 'content-length')) {
       return null;
+    }
 
     var coding = getHeader(headers, 'transfer-encoding');
-
     return coding == null || equalsIgnoreAsciiCase(coding, 'identity')
         ? contentLengthHeader
         : null;
   }
-
-  /// The default media type `application/octet-stream` as defined by HTTP.
-  static final MediaType _defaultMediaType =
-      new MediaType('application', 'octet-stream');
 
   /// Determines the `content-type` from the given [headers] and [body].
   ///

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -167,8 +167,7 @@ abstract class Message {
     if (contentType == null) {
       if (contentLength == null) {
         return headers ?? const HttpUnmodifiableMap.empty();
-      } else if ((contentLength == '0') &&
-          (headers == null || headers.isEmpty)) {
+      } else if (contentLength == '0' && (headers == null || headers.isEmpty)) {
         return _defaultHeaders;
       }
     }
@@ -232,7 +231,7 @@ abstract class Message {
       mediaType = _defaultMediaType;
     }
 
-    if ((body.encoding != null) && (body.encoding != mediaEncoding)) {
+    if (body.encoding != null && body.encoding != mediaEncoding) {
       mediaType = mediaType.change(parameters: {'charset': body.encoding.name});
       changed = true;
     }

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -54,7 +54,8 @@ void main() {
 
     test('default to a constant map', () {
       var message = _createMessage();
-      expect(message.headers.containsKey('content-length'), isFalse);
+      expect(message.headers, hasLength(1));
+      expect(message.headers.containsKey('content-length'), isTrue);
       expect(message.headers, same(_createMessage().headers));
       expect(() => message.headers['h1'] = 'value1', throwsUnsupportedError);
     });
@@ -168,9 +169,9 @@ void main() {
   });
 
   group("content-length", () {
-    test("is null with a default body and without a content-length header", () {
-      var message = _createMessage();
-      expect(message.contentLength, isNull);
+    test("is 0 with a default body and without a content-length header", () {
+      var request = _createMessage();
+      expect(request.contentLength, 0);
     });
 
     test("comes from a byte body", () {


### PR DESCRIPTION
This PR refactors _adjustHeaders into two functions, one for `content-length` and one for `content-type`. This hopefully makes the logic a bit clearer than it currently is and sets up for handling `Map` types.

I want to do this PR before finishing off the `Map` handling as this is a total redo of `_adjustHeaders`.

Tests are all passing which is a plus.