### PR TITLE
Update README to match current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,22 @@ A composable, Future-based library for making HTTP requests.
 
 This package contains a set of high-level functions and classes that make it
 easy to consume HTTP resources. It's platform-independent, and can be used on
-both the command-line and the browser. Currently the global utility functions
-are unsupported on the browser; see "Using on the Browser" below.
+both the command-line and the browser.
 
 ## Using
 
-The easiest way to use this library is via the top-level functions, although
-they currently only work on platforms where `dart:io` is available. They allow
+The easiest way to use this library is via the top-level functions. They allow
 you to make individual HTTP requests with minimal hassle:
 
 ```dart
 import 'package:http/http.dart' as http;
 
-var url = "http://example.com/whatsit/create";
-http.post(url, body: {"name": "doodle", "color": "blue"})
-    .then((response) {
-  print("Response status: ${response.statusCode}");
-  print("Response body: ${response.body}");
-});
+var url = 'http://example.com/whatsit/create';
+var response = await http.post(url, body: {'name': 'doodle', 'color': 'blue'});
+print('Response status: ${response.statusCode}');
+print('Response body: ${response.body}');
 
-http.read("http://example.com/foobar.txt").then(print);
+http.read('http://example.com/foobar.txt').then(print);
 ```
 
 If you're making multiple requests to the same server, you can keep open a
@@ -33,29 +29,30 @@ If you do this, make sure to close the client when you're done:
 
 ```dart
 var client = new http.Client();
-client.post(
-    "http://example.com/whatsit/create",
-    body: {"name": "doodle", "color": "blue"})
-  .then((response) => client.get(response.bodyFields['uri']))
-  .then((response) => print(response.body))
-  .whenComplete(client.close);
+try {
+  var uriResponse = await client.post('http://example.com/whatsit/create',
+      body: {'name': 'doodle', 'color': 'blue'});
+  print(await client.get(uriResponse.bodyFields['uri']));
+} finally {
+  client.close();
+}
 ```
 
 You can also exert more fine-grained control over your requests and responses by
 creating [Request][] or [StreamedRequest][] objects yourself and passing them to
 [Client.send][].
 
-[Request]: https://www.dartdocs.org/documentation/http/latest/http/Request-class.html
-[StreamedRequest]: https://www.dartdocs.org/documentation/http/latest/http/StreamedRequest-class.html
-[Client.send]: https://www.dartdocs.org/documentation/http/latest/http/Client/send.html
+[Request]: https://pub.dartlang.org/documentation/http/latest/http/Request-class.html
+[StreamedRequest]: https://pub.dartlang.org/documentation/http/latest/http/StreamedRequest-class.html
+[Client.send]: https://pub.dartlang.org/documentation/http/latest/http/Client/send.html
 
 This package is designed to be composable. This makes it easy for external
 libraries to work with one another to add behavior to it. Libraries wishing to
 add behavior should create a subclass of [BaseClient][] that wraps another
 [Client][] and adds the desired behavior:
 
-[BaseClient]: https://www.dartdocs.org/documentation/http/latest/http/BaseClient-class.html
-[Client]: https://www.dartdocs.org/documentation/http/latest/http/Client-class.html
+[BaseClient]: https://pub.dartlang.org/documentation/http/latest/http/BaseClient-class.html
+[Client]: https://pub.dartlang.org/documentation/http/latest/http/Client-class.html
 
 ```dart
 class UserAgentClient extends http.BaseClient {
@@ -68,27 +65,5 @@ class UserAgentClient extends http.BaseClient {
     request.headers['user-agent'] = userAgent;
     return _inner.send(request);
   }
-}
-```
-
-## Using on the Browser
-
-The HTTP library can be used on the browser via the [BrowserClient][] class in
-`package:http/browser_client.dart`. This client translates requests into
-XMLHttpRequests. For example:
-
-[BrowserClient]: https://www.dartdocs.org/documentation/http/latest/http.browser_client/BrowserClient-class.html
-
-```dart
-import 'dart:async';
-import 'package:http/browser_client.dart';
-
-main() async {
-  var client = new BrowserClient();
-  var url = '/whatsit/create';
-  var response =
-      await client.post(url, body: {'name': 'doodle', 'color': 'blue'});
-  print('Response status: ${response.statusCode}');
-  print('Response body: ${response.body}');
 }
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var response = await http.post(url, body: {'name': 'doodle', 'color': 'blue'});
 print('Response status: ${response.statusCode}');
 print('Response body: ${response.body}');
 
-http.read('http://example.com/foobar.txt').then(print);
+print(await http.read('http://example.com/foobar.txt'));
 ```
 
 If you're making multiple requests to the same server, you can keep open a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.12.0+1
+version: 0.12.1-dev
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/http
 description: A composable, cross-platform, Future-based API for making HTTP requests.


### PR DESCRIPTION
Closes #240

- Remove the browser specific sections and caveats - these are no longer
  necessary to call out since this package uses config specific imports.
- Use single quoted strings consistently for style.
- Update samples to use async/await.
- Update doc links to point to the pub site.