### PR TITLE
Fix conditional import for multipart file implementations

### DIFF
--- a/lib/src/multipart_file.dart
+++ b/lib/src/multipart_file.dart
@@ -13,7 +13,7 @@ import 'utils.dart';
 // ignore: uri_does_not_exist
 import 'multipart_file_stub.dart'
     // ignore: uri_does_not_exist
-    if (dart.library.io) 'multipart_file_io.dart';
+    if (!dart.library.js) 'multipart_file_io.dart';
 
 /// A file to be uploaded as part of a [MultipartRequest]. This doesn't need to
 /// correspond to a physical file.

--- a/lib/src/multipart_file.dart
+++ b/lib/src/multipart_file.dart
@@ -11,9 +11,9 @@ import 'byte_stream.dart';
 import 'utils.dart';
 
 // ignore: uri_does_not_exist
-import 'multipart_file_stub.dart'
+import 'multipart_file_io.dart'
     // ignore: uri_does_not_exist
-    if (!dart.library.js) 'multipart_file_io.dart';
+    if (dart.library.js) 'multipart_file_stub.dart';
 
 /// A file to be uploaded as part of a [MultipartRequest]. This doesn't need to
 /// correspond to a physical file.


### PR DESCRIPTION
I got this message when I was compiling flutter for web:
```
Error compiling dartdevc module:http|lib/http.ddc.js

packages/http/src/multipart_file.dart:14:8: Error: Error when reading 'packages/http/src/multipart_file_stub.dart': File not found
import 'multipart_file_stub.dart'
       ^
packages/http/src/multipart_file.dart:93:7: Error: Method not found: 'multipartFileFromPath'.
      multipartFileFromPath(field, filePath,
      ^^^^^^^^^^^^^^^^^^^^^
```

With this PR it works again.