### PR TITLE
Adjustable boundary (#295)

### DIFF
--- a/lib/src/multipart_request.dart
+++ b/lib/src/multipart_request.dart
@@ -44,10 +44,14 @@ class MultipartRequest extends BaseRequest {
   /// The private version of [files].
   final List<MultipartFile> _files;
 
+  /// The boundary prefix. When not set, defaults to "dart-http-boundary-".
+  String boundaryPrefix;
+
   /// Creates a new [MultipartRequest].
   MultipartRequest(String method, Uri url)
       : fields = {},
         _files = <MultipartFile>[],
+        boundaryPrefix = "dart-http-boundary-",
         super(method, url);
 
   /// The list of files to upload for this request.
@@ -160,7 +164,7 @@ class MultipartRequest extends BaseRequest {
 
   /// Returns a randomly-generated multipart boundary string
   String _boundaryString() {
-    var prefix = "dart-http-boundary-";
+    var prefix = boundaryPrefix;
     var list = List<int>.generate(
         _BOUNDARY_LENGTH - prefix.length,
         (index) =>

--- a/lib/src/multipart_request.dart
+++ b/lib/src/multipart_request.dart
@@ -45,13 +45,13 @@ class MultipartRequest extends BaseRequest {
   final List<MultipartFile> _files;
 
   /// The boundary prefix. When not set, defaults to "dart-http-boundary-".
-  String boundaryPrefix;
+  final String boundaryPrefix;
 
   /// Creates a new [MultipartRequest].
-  MultipartRequest(String method, Uri url)
+  MultipartRequest(String method, Uri url, {String boundaryPrefix})
       : fields = {},
         _files = <MultipartFile>[],
-        boundaryPrefix = "dart-http-boundary-",
+        boundaryPrefix = boundaryPrefix ?? "dart-http-boundary-",
         super(method, url);
 
   /// The list of files to upload for this request.


### PR DESCRIPTION
One would be able to adjust the boundary prefix. When not set, defaults to "dart-http-boundary-".