### PR TITLE
Fix a broken test for redirects

### DIFF
--- a/test/io/request_test.dart
+++ b/test/io/request_test.dart
@@ -14,7 +14,7 @@ void main() {
 
   tearDown(stopServer);
 
-  test('.send', () async {
+  test('send happy case', () async {
     final request = http.Request('GET', serverUrl)
       ..body = 'hello'
       ..headers['User-Agent'] = 'Dart';
@@ -38,7 +38,7 @@ void main() {
         })));
   });
 
-  test('#followRedirects', () async {
+  test('without redirects', () async {
     final request = http.Request('GET', serverUrl.resolve('/redirect'))
       ..followRedirects = false;
     final response = await request.send();
@@ -46,7 +46,7 @@ void main() {
     expect(response.statusCode, equals(302));
   });
 
-  test('#maxRedirects', () async {
+  test('exceeding max redirects', () async {
     final request = http.Request('GET', serverUrl.resolve('/loop?1'))
       ..maxRedirects = 2;
     expect(

--- a/test/io/utils.dart
+++ b/test/io/utils.dart
@@ -119,14 +119,6 @@ void stopServer() {
 /// A matcher for functions that throw HttpException.
 Matcher get throwsClientException => throwsA(TypeMatcher<ClientException>());
 
-/// A matcher for RedirectLimitExceededExceptions.
-final isRedirectLimitExceededException = const TypeMatcher<RedirectException>()
-    .having((e) => e.message, 'message', 'Redirect limit exceeded');
-
-/// A matcher for functions that throw RedirectLimitExceededException.
-final Matcher throwsRedirectLimitExceededException =
-    throwsA(isRedirectLimitExceededException);
-
 /// A matcher for functions that throw SocketException.
 final Matcher throwsSocketException =
     throwsA(const TypeMatcher<SocketException>());


### PR DESCRIPTION
This test added a `.catchError` callback with some expects, but the
`Future` was completing normally so the callback and expects never ran.
The reason the response came back successfully was that the IO client
does not consider a `302` to be a redirect when the method is `'POST'`.

https://github.com/dart-lang/sdk/blob/ed9e89ea388e4bc0142bf6e967d4ca11999bdfdc/sdk/lib/_http/http_impl.dart#L355-L365

- Refactor to async/await to clean up the noise of `.then`,
  `.whenComplete`, and `.catchError` and make the logic easier to
  follow.
- Switch the request type to `'GET'` so that the exception occurs.
- Move server starting and stopping to a `setUp` and `tearDown`.
- Fix the expectation to look for the wrapped `ClientException` instead
  of the exception thrown by the IO client. We also lose the underlying
  exception and have only the message so we can't check the length of
  the `redirects` field.
- Remove the now unused test utility to get a matcher on the old
  exception type.