### PR TITLE
Drop an obsolete hack for async as argument name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - dev
-  - 2.2.0
+  - 2.4.0
 
 dart_task:
   - test: --platform vm

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -45,8 +45,8 @@ class BrowserClient extends BaseClient {
     var bytes = await request.finalize().toBytes();
     var xhr = HttpRequest();
     _xhrs.add(xhr);
-    _openHttpRequest(xhr, request.method, request.url.toString(), asynch: true);
     xhr
+      ..open(request.method, '${request.url}', async: true)
       ..responseType = 'blob'
       ..withCredentials = withCredentials;
     request.headers.forEach(xhr.setRequestHeader);
@@ -91,12 +91,6 @@ class BrowserClient extends BaseClient {
     } finally {
       _xhrs.remove(xhr);
     }
-  }
-
-  // TODO(nweiz): Remove this when sdk#24637 is fixed.
-  void _openHttpRequest(HttpRequest request, String method, String url,
-      {bool asynch, String user, String password}) {
-    request.open(method, url, async: asynch, user: user, password: password);
   }
 
   /// Closes the client.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
   async: ">=1.10.0 <3.0.0"


### PR DESCRIPTION
This was working around a bug where in an `async` method you couldn't
use `async` as a named argument in a call.