### PR TITLE
Fixes #293, added property `url` to BaseResponse.

### DIFF
--- a/lib/src/base_request.dart
+++ b/lib/src/base_request.dart
@@ -122,6 +122,7 @@ abstract class BaseRequest {
           contentLength: response.contentLength,
           request: response.request,
           headers: response.headers,
+          url: response.url,
           isRedirect: response.isRedirect,
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase);

--- a/lib/src/base_response.dart
+++ b/lib/src/base_response.dart
@@ -28,6 +28,9 @@ abstract class BaseResponse {
   // TODO(nweiz): make this a HttpHeaders object.
   final Map<String, String> headers;
 
+  /// The url of the final response(possibly after redirections).
+  final String url;
+
   final bool isRedirect;
 
   /// Whether the server requested that a persistent connection be maintained.
@@ -37,6 +40,7 @@ abstract class BaseResponse {
       {this.contentLength,
       this.request,
       this.headers = const {},
+      this.url,
       this.isRedirect = false,
       this.persistentConnection = true,
       this.reasonPhrase}) {

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -65,6 +65,7 @@ class BrowserClient extends BaseClient {
             contentLength: body.length,
             request: request,
             headers: xhr.responseHeaders,
+            url: xhr.responseUrl,
             reasonPhrase: xhr.statusText));
       });
 

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -55,6 +55,9 @@ class IOClient extends BaseClient {
               response.contentLength == -1 ? null : response.contentLength,
           request: request,
           headers: headers,
+          url: response.redirects.isEmpty
+              ? request.url.toString()
+              : response.redirects.last.location.toString(),
           isRedirect: response.isRedirect,
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase);

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -32,12 +32,14 @@ class Response extends BaseResponse {
   Response(String body, int statusCode,
       {BaseRequest request,
       Map<String, String> headers = const {},
+      String url,
       bool isRedirect = false,
       bool persistentConnection = true,
       String reasonPhrase})
       : this.bytes(_encodingForHeaders(headers).encode(body), statusCode,
             request: request,
             headers: headers,
+            url: url,
             isRedirect: isRedirect,
             persistentConnection: persistentConnection,
             reasonPhrase: reasonPhrase);
@@ -46,6 +48,7 @@ class Response extends BaseResponse {
   Response.bytes(List<int> bodyBytes, int statusCode,
       {BaseRequest request,
       Map<String, String> headers = const {},
+      String url,
       bool isRedirect = false,
       bool persistentConnection = true,
       String reasonPhrase})
@@ -54,6 +57,7 @@ class Response extends BaseResponse {
             contentLength: bodyBytes.length,
             request: request,
             headers: headers,
+            url: url,
             isRedirect: isRedirect,
             persistentConnection: persistentConnection,
             reasonPhrase: reasonPhrase);
@@ -65,6 +69,7 @@ class Response extends BaseResponse {
       return Response.bytes(body, response.statusCode,
           request: response.request,
           headers: response.headers,
+          url: response.url,
           isRedirect: response.isRedirect,
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase);

--- a/lib/src/streamed_response.dart
+++ b/lib/src/streamed_response.dart
@@ -24,6 +24,7 @@ class StreamedResponse extends BaseResponse {
       {int contentLength,
       BaseRequest request,
       Map<String, String> headers = const {},
+      String url,
       bool isRedirect = false,
       bool persistentConnection = true,
       String reasonPhrase})
@@ -32,6 +33,7 @@ class StreamedResponse extends BaseResponse {
             contentLength: contentLength,
             request: request,
             headers: headers,
+            url: url,
             isRedirect: isRedirect,
             persistentConnection: persistentConnection,
             reasonPhrase: reasonPhrase);

--- a/test/io/request_test.dart
+++ b/test/io/request_test.dart
@@ -22,6 +22,7 @@ void main() {
     final response = await request.send();
 
     expect(response.statusCode, equals(200));
+    expect(response.url, equals(serverUrl.toString()));
     final bytesString = await response.stream.bytesToString();
     expect(
         bytesString,
@@ -44,6 +45,7 @@ void main() {
     final response = await request.send();
 
     expect(response.statusCode, equals(302));
+    expect(response.url, equals(serverUrl.resolve('/redirect').toString()));
   });
 
   test('with redirects', () async {
@@ -51,6 +53,7 @@ void main() {
     final response = await request.send();
 
     expect(response.statusCode, equals(200));
+    expect(response.url, equals(serverUrl.resolve('/').toString()));
     final bytesString = await response.stream.bytesToString();
     expect(bytesString, parse(containsPair('path', '/')));
   });


### PR DESCRIPTION
The final url is extract from XMLHttpRequest.responseURL(on browsers)
or HttpClientResponse.redirects.last.location(on vm).
Also added tests for vm.
No tests were written for browser, since server tests for brower is
broken and needs to be fixed.