### PR TITLE
Refactor to async/await

### DIFF
--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -121,11 +121,10 @@ abstract class BaseClient implements Client {
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
   @override
-  Future<String> read(url, {Map<String, String> headers}) {
-    return get(url, headers: headers).then((response) {
-      _checkResponseSuccess(url, response);
-      return response.body;
-    });
+  Future<String> read(url, {Map<String, String> headers}) async {
+    final response = await get(url, headers: headers);
+    _checkResponseSuccess(url, response);
+    return response.body;
   }
 
   /// Sends an HTTP GET request with the given headers to the given URL, which
@@ -138,11 +137,10 @@ abstract class BaseClient implements Client {
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
   @override
-  Future<Uint8List> readBytes(url, {Map<String, String> headers}) {
-    return get(url, headers: headers).then((response) {
-      _checkResponseSuccess(url, response);
-      return response.bodyBytes;
-    });
+  Future<Uint8List> readBytes(url, {Map<String, String> headers}) async {
+    final response = await get(url, headers: headers);
+    _checkResponseSuccess(url, response);
+    return response.bodyBytes;
   }
 
   /// Sends an HTTP request and asynchronously returns the response.

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -30,42 +30,39 @@ class MockClient extends BaseClient {
   /// Creates a [MockClient] with a handler that receives [Request]s and sends
   /// [Response]s.
   MockClient(MockClientHandler fn)
-      : this._((baseRequest, bodyStream) {
-          return bodyStream.toBytes().then((bodyBytes) {
-            var request = Request(baseRequest.method, baseRequest.url)
-              ..persistentConnection = baseRequest.persistentConnection
-              ..followRedirects = baseRequest.followRedirects
-              ..maxRedirects = baseRequest.maxRedirects
-              ..headers.addAll(baseRequest.headers)
-              ..bodyBytes = bodyBytes
-              ..finalize();
+      : this._((baseRequest, bodyStream) async {
+          final bodyBytes = await bodyStream.toBytes();
+          var request = Request(baseRequest.method, baseRequest.url)
+            ..persistentConnection = baseRequest.persistentConnection
+            ..followRedirects = baseRequest.followRedirects
+            ..maxRedirects = baseRequest.maxRedirects
+            ..headers.addAll(baseRequest.headers)
+            ..bodyBytes = bodyBytes
+            ..finalize();
 
-            return fn(request);
-          }).then((response) {
-            return StreamedResponse(
-                ByteStream.fromBytes(response.bodyBytes), response.statusCode,
-                contentLength: response.contentLength,
-                request: baseRequest,
-                headers: response.headers,
-                isRedirect: response.isRedirect,
-                persistentConnection: response.persistentConnection,
-                reasonPhrase: response.reasonPhrase);
-          });
+          final response = await fn(request);
+          return StreamedResponse(
+              ByteStream.fromBytes(response.bodyBytes), response.statusCode,
+              contentLength: response.contentLength,
+              request: baseRequest,
+              headers: response.headers,
+              isRedirect: response.isRedirect,
+              persistentConnection: response.persistentConnection,
+              reasonPhrase: response.reasonPhrase);
         });
 
   /// Creates a [MockClient] with a handler that receives [StreamedRequest]s and
   /// sends [StreamedResponse]s.
   MockClient.streaming(MockClientStreamHandler fn)
-      : this._((request, bodyStream) {
-          return fn(request, bodyStream).then((response) {
-            return StreamedResponse(response.stream, response.statusCode,
-                contentLength: response.contentLength,
-                request: request,
-                headers: response.headers,
-                isRedirect: response.isRedirect,
-                persistentConnection: response.persistentConnection,
-                reasonPhrase: response.reasonPhrase);
-          });
+      : this._((request, bodyStream) async {
+          final response = await fn(request, bodyStream);
+          return StreamedResponse(response.stream, response.statusCode,
+              contentLength: response.contentLength,
+              request: request,
+              headers: response.headers,
+              isRedirect: response.isRedirect,
+              persistentConnection: response.persistentConnection,
+              reasonPhrase: response.reasonPhrase);
         });
 
   @override

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -60,15 +60,14 @@ class Response extends BaseResponse {
 
   /// Creates a new HTTP response by waiting for the full body to become
   /// available from a [StreamedResponse].
-  static Future<Response> fromStream(StreamedResponse response) {
-    return response.stream.toBytes().then((body) {
-      return Response.bytes(body, response.statusCode,
-          request: response.request,
-          headers: response.headers,
-          isRedirect: response.isRedirect,
-          persistentConnection: response.persistentConnection,
-          reasonPhrase: response.reasonPhrase);
-    });
+  static Future<Response> fromStream(StreamedResponse response) async {
+    final body = await response.stream.toBytes();
+    return Response.bytes(body, response.statusCode,
+        request: response.request,
+        headers: response.headers,
+        isRedirect: response.isRedirect,
+        persistentConnection: response.persistentConnection,
+        reasonPhrase: response.reasonPhrase);
   }
 }
 

--- a/test/multipart_test.dart
+++ b/test/multipart_test.dart
@@ -241,7 +241,7 @@ void main() {
   });
 
   test('with a file that has an error', () async {
-    var file = http.MultipartFile('file', Stream.error('error'), 1);
+    var file = http.MultipartFile('file', Future.error('error').asStream(), 1);
     var request = http.MultipartRequest('POST', dummyUrl)..files.add(file);
     expect(request.finalize().drain(), throwsA('error'));
   });

--- a/test/multipart_test.dart
+++ b/test/multipart_test.dart
@@ -239,4 +239,10 @@ void main() {
         --{{boundary}}--
         '''));
   });
+
+  test('with a file that has an error', () async {
+    var file = http.MultipartFile('file', Stream.error('error'), 1);
+    var request = http.MultipartRequest('POST', dummyUrl)..files.add(file);
+    expect(request.finalize().drain(), throwsA('error'));
+  });
 }

--- a/test/multipart_test.dart
+++ b/test/multipart_test.dart
@@ -241,7 +241,8 @@ void main() {
   });
 
   test('with a file that has an error', () async {
-    var file = http.MultipartFile('file', Future.error('error').asStream(), 1);
+    var file = http.MultipartFile(
+        'file', Future<List<int>>.error('error').asStream(), 1);
     var request = http.MultipartRequest('POST', dummyUrl)..files.add(file);
     expect(request.finalize().drain(), throwsA('error'));
   });


### PR DESCRIPTION
Use an `async*` for `MultipartRequest.finalize()`. 

Refactor `.then` chains to async methods.

Add a test demonstrated that errors are forwarded though
a multipart request finalize stream.