### PR TITLE
(BrowserClient) add constructor to set withCredentials value

### DIFF
--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -39,6 +39,9 @@ class BrowserClient extends BaseClient {
   /// Defaults to `false`.
   bool withCredentials = false;
 
+  /// Creates a new HTTP client.
+  BrowserClient({this.withCredentials});
+
   /// Sends an HTTP request and asynchronously returns the response.
   @override
   Future<StreamedResponse> send(BaseRequest request) async {


### PR DESCRIPTION
Hi,

I just added a constructor that takes an optional `withCredentials` value.