### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,7 +1,7 @@
 import 'dart:convert' as convert;
 import 'package:http/http.dart' as http;
 
-main(List<String> arguments) async {
+void main(List<String> arguments) async {
   // This example uses the Google Books API to search for books about http.
   // https://developers.google.com/books/docs/overview
   var url = 'https://www.googleapis.com/books/v1/volumes?q={http}';

--- a/lib/http.dart
+++ b/lib/http.dart
@@ -160,7 +160,7 @@ Future<String> read(url, {Map<String, String> headers}) =>
 Future<Uint8List> readBytes(url, {Map<String, String> headers}) =>
     _withClient((client) => client.readBytes(url, headers: headers));
 
-Future<T> _withClient<T>(Future<T> fn(Client client)) async {
+Future<T> _withClient<T>(Future<T> Function(Client) fn) async {
   var client = Client();
   try {
     return await fn(client);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -69,7 +69,7 @@ ByteStream toByteStream(Stream<List<int>> stream) {
 ///
 /// The return value, also a single-subscription [Stream] should be used in
 /// place of [stream] after calling this method.
-Stream<T> onDone<T>(Stream<T> stream, void onDone()) =>
+Stream<T> onDone<T>(Stream<T> stream, void Function() onDone) =>
     stream.transform(StreamTransformer.fromHandlers(handleDone: (sink) {
       sink.close();
       onDone();

--- a/test/io/http_test.dart
+++ b/test/io/http_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart';
 
 import 'utils.dart';
 
-main() {
+void main() {
   group('http.', () {
     setUp(startServer);
 


### PR DESCRIPTION
- always_declare_return_types
- use_function_type_syntax_for_parameters