### PR TITLE
Drop the author field from pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: http
 version: 0.12.0+3
-author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 


### PR DESCRIPTION
This field is no longer used by pub.