### PR TITLE
Fix to include Content-Type header in MultipartRequest

### DIFF
--- a/lib/src/multipart_request.dart
+++ b/lib/src/multipart_request.dart
@@ -87,13 +87,16 @@ class MultipartRequest extends BaseRequest {
   /// Freezes all mutable fields and returns a single-subscription [ByteStream]
   /// that will emit the request body.
   @override
-  ByteStream finalize() => ByteStream(_finalize());
-
-  Stream<List<int>> _finalize() async* {
+  ByteStream finalize() {
     // TODO(nweiz): freeze fields and files
     var boundary = _boundaryString();
     headers['content-type'] = 'multipart/form-data; boundary=$boundary';
     super.finalize();
+
+    return ByteStream(_finalize(boundary));
+  }
+
+  Stream<List<int>> _finalize(String boundary) async* {
     const line = [13, 10]; // \r\n
     final separator = utf8.encode('--$boundary\r\n');
     final close = utf8.encode('--$boundary--\r\n');


### PR DESCRIPTION
Fixes: #351

Run synchronously until super.finalize method is called.