### PR TITLE
Remove usages of Delegating*.typed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.12.1-dev
+
 ## 0.12.0+4
 
 * Fix a bug setting the `'content-type'` header in `MultipartRequest`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.12.1-dev
 
+* Remove dependency on `package:async`.
+
 ## 0.12.0+4
 
 * Fix a bug setting the `'content-type'` header in `MultipartRequest`.

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -5,8 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:async/async.dart';
-
 import 'base_client.dart';
 import 'base_request.dart';
 import 'exception.dart';
@@ -39,9 +37,7 @@ class IOClient extends BaseClient {
         ioRequest.headers.set(name, value);
       });
 
-      var response =
-          await stream.pipe(DelegatingStreamConsumer.typed(ioRequest))
-              as HttpClientResponse;
+      var response = await stream.pipe(ioRequest) as HttpClientResponse;
 
       var headers = <String, String>{};
       response.headers.forEach((key, values) {
@@ -49,7 +45,7 @@ class IOClient extends BaseClient {
       });
 
       return StreamedResponse(
-          DelegatingStream.typed<List<int>>(response).handleError(
+          response.handleError(
               (HttpException error) =>
                   throw ClientException(error.message, error.uri),
               test: (error) => error is HttpException),

--- a/lib/src/multipart_file_io.dart
+++ b/lib/src/multipart_file_io.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:async/async.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:path/path.dart' as p;
 
@@ -17,7 +16,7 @@ Future<MultipartFile> multipartFileFromPath(String field, String filePath,
   filename ??= p.basename(filePath);
   var file = File(filePath);
   var length = await file.length();
-  var stream = ByteStream(DelegatingStream.typed(file.openRead()));
+  var stream = ByteStream(file.openRead());
   return MultipartFile(field, stream, length,
       filename: filename, contentType: contentType);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.12.0+4
+version: 0.12.1-dev
 homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 
@@ -7,7 +7,6 @@ environment:
   sdk: ">=2.4.0 <3.0.0"
 
 dependencies:
-  async: ">=1.10.0 <3.0.0"
   http_parser: ">=0.0.1 <4.0.0"
   path: ">=0.9.0 <2.0.0"
   pedantic: "^1.0.0"


### PR DESCRIPTION
These usages all pass static type checking without being wrapped in
extra layers.