### PR TITLE
Pass a Function(dynamic) to stream.handleError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.2
+
+* Fix error handler callback type for response stream errors to avoid masking
+  root causes.
+
 ## 0.12.1
 
 * Add `IOStreamedResponse` which includes the ability to detach the socket.

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -45,10 +45,10 @@ class IOClient extends BaseClient {
       });
 
       return IOStreamedResponse(
-          response.handleError(
-              (HttpException error) =>
-                  throw ClientException(error.message, error.uri),
-              test: (error) => error is HttpException),
+          response.handleError((error) {
+            final httpException = error as HttpException;
+            throw ClientException(httpException.message, httpException.uri);
+          }, test: (error) => error is HttpException),
           response.statusCode,
           contentLength:
               response.contentLength == -1 ? null : response.contentLength,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.12.1
+version: 0.12.2
 homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 


### PR DESCRIPTION
Fixes #418

The argument type for `handleError` is `Function` to allow callbacks
that do or don't take the `StackTrace` argument, so we don't get static
checking. In either case the first argument is expected to allow
`dynamic`.

TODO: Add a test