### PR TITLE
fix crash when passing null value through map

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -16,7 +16,7 @@ String mapToQuery(Map<String, String> map, {Encoding encoding}) {
   var pairs = <List<String>>[];
   map.forEach((key, value) => pairs.add([
         Uri.encodeQueryComponent(key, encoding: encoding),
-        Uri.encodeQueryComponent(value, encoding: encoding)
+        Uri.encodeQueryComponent(value ?? '', encoding: encoding)
       ]));
   return pairs.map((pair) => '${pair[0]}=${pair[1]}').join('&');
 }


### PR DESCRIPTION
Either this or an exception should be thrown informing the user, that the map passed through the body parameter,
can't have null values.

Otherwise this will be thrown (which is not all to helpful)
```
Unhandled exception:
NoSuchMethodError: The getter 'length' was called on null.
Receiver: null
Tried calling: length
#0      Object.noSuchMethod  (dart:core-patch/object_patch.dart:51:5)
#1      _Uri._uriEncode  (dart:core-patch/uri_patch.dart:44:23)
#2      Uri.encodeQueryComponent  (dart:core/uri.dart:1103:17)
#3      mapToQuery.<anonymous closure> 
package:http/src/utils.dart:19
#4      CastMap.forEach.<anonymous closure>  (dart:_internal/cast.dart:288:8)
#5      _LinkedHashMapMixin.forEach  (dart:collection-patch/compact_hash.dart:377:8)
#6      CastMap.forEach  (dart:_internal/cast.dart:287:13)
#7      mapToQuery 
package:http/src/utils.dart:17
#8      Request.bodyFields= 
package:http/src/request.dart:137
#9      BaseClient._sendUnstreamed 
package:http/src/base_client.dart:85
#10     BaseClient.post 
package:http/src/base_client.dart:32
#11     post.<anonymous closure> 
package:http/http.dart:70
#12     _withClient 
package:http/http.dart:166
```