### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A composable, [Future]-based library for making HTTP requests.
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/lib/src/base_request.dart
+++ b/lib/src/base_request.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:collection';
 
 import 'byte_stream.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'base_client.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';

--- a/lib/src/multipart_file.dart
+++ b/lib/src/multipart_file.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:http_parser/http_parser.dart';

--- a/lib/src/multipart_file_io.dart
+++ b/lib/src/multipart_file_io.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:http_parser/http_parser.dart';

--- a/lib/src/multipart_file_stub.dart
+++ b/lib/src/multipart_file_stub.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:http_parser/http_parser.dart';
 
 import 'multipart_file.dart';

--- a/lib/src/multipart_request.dart
+++ b/lib/src/multipart_request.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 

--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 

--- a/lib/src/streamed_response.dart
+++ b/lib/src/streamed_response.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'base_request.dart';
 import 'base_response.dart';
 import 'byte_stream.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core