### PR TITLE
Prepare publish 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.3
+
+* Remove unnecessary dart:async imports.
+
 ## 0.12.2
 
 * Fix error handler callback type for response stream errors to avoid masking

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.12.2
+version: 0.12.3
 homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 


### PR DESCRIPTION
This has to be published & pulled into the dart SDK in order to be rolled into google3 right, now that http has been unforked?