### PR TITLE
BrowserClient - withCredentials 'true' by default.

### DIFF
--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -36,8 +36,8 @@ class BrowserClient extends BaseClient {
   /// Whether to send credentials such as cookies or authorization headers for
   /// cross-site requests.
   ///
-  /// Defaults to `false`.
-  bool withCredentials = false;
+  /// Defaults to `true`.
+  bool withCredentials = true;
 
   /// Sends an HTTP request and asynchronously returns the response.
   @override


### PR DESCRIPTION
'withCredentials = true' is needed for browser cookies in Flutter Web XmlHttpRequests.
Because current pattern requires a parameterless constructor, only way to change the setting is to set it by default. 
There is no harm in having it always set to true - credentials are ignored if not present.