### PR TITLE
Migrate BrowserClient from blob to arraybuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ This release will be pinned to only allow pre-release sdk versions starting from
 2.10.0-2.0.dev, which is the first version where this package will appear in the
 null safety allow list.
 
-- Added `const` constructor to `ByteStream`.
+* Add `const` constructor to `ByteStream`.
+* Migrate `BrowserClient` from `blob` to `arraybuffer`.
 
 ## 0.12.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 
 environment:
-  sdk: '>=2.10.0-2.0.dev <2.11.0'
+  sdk: '>=2.12.0-0 <2.13.0'
 
 # Cannot be published until null safety ships
 publish_to: none


### PR DESCRIPTION
This allows BrowserClient to be used on Cobalt (which
doesn't support blob in XHR).

"blob" was used as a workaround for the Dart issue #18542.
Since the issue is closed, using "arraybuffer" is more
straightforward and efficient.