### PR TITLE
Make SocketException catchable

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -166,6 +166,8 @@ Future<T> _withClient<T>(Future<T> Function(Client) fn) async {
   var client = Client();
   try {
     return await fn(client);
+  } catch (e) {
+    rethrow;
   } finally {
     client.close();
   }

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -89,8 +89,11 @@ abstract class BaseClient implements Client {
         throw ArgumentError('Invalid request body "$body".');
       }
     }
-
-    return Response.fromStream(await send(request));
+    try {
+      return Response.fromStream(await send(request));
+    } catch (e) {
+      rethrow;
+    }
   }
 
   /// Throws an error if [response] is not successful.

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -57,6 +57,8 @@ class IOClient extends BaseClient {
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase,
           inner: response);
+    } on SocketException catch (error) {
+      throw ClientException(error.message, error);
     } on HttpException catch (error) {
       throw ClientException(error.message, error.uri);
     }

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -58,7 +58,7 @@ class IOClient extends BaseClient {
           reasonPhrase: response.reasonPhrase,
           inner: response);
     } on SocketException catch (error) {
-      throw ClientException(error.message, error);
+      throw ClientException(error.message, request.uri);
     } on HttpException catch (error) {
       throw ClientException(error.message, error.uri);
     }

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -58,7 +58,7 @@ class IOClient extends BaseClient {
           reasonPhrase: response.reasonPhrase,
           inner: response);
     } on SocketException catch (error) {
-      throw ClientException(error.message, request.uri);
+      throw ClientException(error.message, request.url);
     } on HttpException catch (error) {
       throw ClientException(error.message, error.uri);
     }

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -57,8 +57,8 @@ class IOClient extends BaseClient {
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase,
           inner: response);
-    } on SocketException catch (error) {
-      throw ClientException(error.message, request.url);
+    } on SocketException catch (_) {
+      rethrow;
     } on HttpException catch (error) {
       throw ClientException(error.message, error.uri);
     }


### PR DESCRIPTION
You can check if that fixes everything, but for me it worked as expected. Before I had the annoying issue that my app would crash completely without any try-catch etc. helping in any way if my phone was simply offline. Now I can catch the SocketException with the try-catch around my http.get.

```dart
Future<User> getMe() async {
    try {
      final http.Response response = await http.get(
        baseUrl + "user/",
        headers: await defaultHeaders,
      );
      print("getMe: ${json.decode(utf8.decode(response.bodyBytes))}");
      if (response.statusCode == 200) {
        return User.fromJson(json.decode(utf8.decode(response.bodyBytes)));
      } else {
        String errorMsg =
            Error.fromJson(json.decode(utf8.decode(response.bodyBytes)))
                .message;
        return Future.error(errorMsg);
      }
    } catch (e) {
      print("getMe: $e");
      // THIS IS WHERE THE SOCKETEXCEPTION IS CATCHED
      return Future.error(_prepareError(e));
    }
  }
```