### PR TITLE
Add support for request timeout

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A composable, [Future]-based library for making HTTP requests.
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -27,6 +28,10 @@ export 'src/streamed_response.dart';
 
 /// Sends an HTTP HEAD request with the given headers to the given URL.
 ///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
+///
 /// This automatically initializes a new [Client] and closes that client once
 /// the request is complete. If you're planning on making multiple requests to
 /// the same server, you should use a single [Client] for all of those requests.
@@ -38,6 +43,10 @@ Future<Response> head(Uri url,
         (client) => client.head(url, headers: headers, timeout: timeout));
 
 /// Sends an HTTP GET request with the given headers to the given URL.
+///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
 ///
 /// This automatically initializes a new [Client] and closes that client once
 /// the request is complete. If you're planning on making multiple requests to
@@ -65,6 +74,10 @@ Future<Response> get(Uri url,
 ///
 /// [encoding] defaults to [utf8].
 ///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
+///
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> post(Uri url,
@@ -90,6 +103,10 @@ Future<Response> post(Uri url,
 /// `"application/x-www-form-urlencoded"`; this cannot be overridden.
 ///
 /// [encoding] defaults to [utf8].
+///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
 ///
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
@@ -118,6 +135,10 @@ Future<Response> put(Uri url,
 ///
 /// [encoding] defaults to [utf8].
 ///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
+///
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> patch(Uri url,
@@ -129,6 +150,10 @@ Future<Response> patch(Uri url,
         headers: headers, body: body, encoding: encoding, timeout: timeout));
 
 /// Sends an HTTP DELETE request with the given headers to the given URL.
+///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
 ///
 /// This automatically initializes a new [Client] and closes that client once
 /// the request is complete. If you're planning on making multiple requests to
@@ -149,6 +174,10 @@ Future<Response> delete(Uri url,
 /// The Future will emit a [ClientException] if the response doesn't have a
 /// success status code.
 ///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
+///
 /// This automatically initializes a new [Client] and closes that client once
 /// the request is complete. If you're planning on making multiple requests to
 /// the same server, you should use a single [Client] for all of those requests.
@@ -166,6 +195,10 @@ Future<String> read(Uri url,
 ///
 /// The Future will emit a [ClientException] if the response doesn't have a
 /// success status code.
+///
+/// If [timeout] is not null the request will be aborted if it takes longer than
+/// the given duration to complete, and the returned future will complete as an
+/// error with a [TimeoutException].
 ///
 /// This automatically initializes a new [Client] and closes that client once
 /// the request is complete. If you're planning on making multiple requests to

--- a/lib/http.dart
+++ b/lib/http.dart
@@ -32,8 +32,10 @@ export 'src/streamed_response.dart';
 /// the same server, you should use a single [Client] for all of those requests.
 ///
 /// For more fine-grained control over the request, use [Request] instead.
-Future<Response> head(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.head(url, headers: headers));
+Future<Response> head(Uri url,
+        {Map<String, String>? headers, Duration? timeout}) =>
+    _withClient(
+        (client) => client.head(url, headers: headers, timeout: timeout));
 
 /// Sends an HTTP GET request with the given headers to the given URL.
 ///
@@ -42,8 +44,10 @@ Future<Response> head(Uri url, {Map<String, String>? headers}) =>
 /// the same server, you should use a single [Client] for all of those requests.
 ///
 /// For more fine-grained control over the request, use [Request] instead.
-Future<Response> get(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.get(url, headers: headers));
+Future<Response> get(Uri url,
+        {Map<String, String>? headers, Duration? timeout}) =>
+    _withClient(
+        (client) => client.get(url, headers: headers, timeout: timeout));
 
 /// Sends an HTTP POST request with the given headers and body to the given URL.
 ///
@@ -64,9 +68,12 @@ Future<Response> get(Uri url, {Map<String, String>? headers}) =>
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> post(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.post(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        Object? body,
+        Encoding? encoding,
+        Duration? timeout}) =>
+    _withClient((client) => client.post(url,
+        headers: headers, body: body, encoding: encoding, timeout: timeout));
 
 /// Sends an HTTP PUT request with the given headers and body to the given URL.
 ///
@@ -87,9 +94,12 @@ Future<Response> post(Uri url,
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> put(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.put(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        Object? body,
+        Encoding? encoding,
+        Duration? timeout}) =>
+    _withClient((client) => client.put(url,
+        headers: headers, body: body, encoding: encoding, timeout: timeout));
 
 /// Sends an HTTP PATCH request with the given headers and body to the given
 /// URL.
@@ -111,9 +121,12 @@ Future<Response> put(Uri url,
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> patch(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.patch(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        Object? body,
+        Encoding? encoding,
+        Duration? timeout}) =>
+    _withClient((client) => client.patch(url,
+        headers: headers, body: body, encoding: encoding, timeout: timeout));
 
 /// Sends an HTTP DELETE request with the given headers to the given URL.
 ///
@@ -123,9 +136,12 @@ Future<Response> patch(Uri url,
 ///
 /// For more fine-grained control over the request, use [Request] instead.
 Future<Response> delete(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.delete(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        Object? body,
+        Encoding? encoding,
+        Duration? timeout}) =>
+    _withClient((client) => client.delete(url,
+        headers: headers, body: body, encoding: encoding, timeout: timeout));
 
 /// Sends an HTTP GET request with the given headers to the given URL and
 /// returns a Future that completes to the body of the response as a [String].
@@ -139,8 +155,10 @@ Future<Response> delete(Uri url,
 ///
 /// For more fine-grained control over the request and response, use [Request]
 /// instead.
-Future<String> read(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.read(url, headers: headers));
+Future<String> read(Uri url,
+        {Map<String, String>? headers, Duration? timeout}) =>
+    _withClient(
+        (client) => client.read(url, headers: headers, timeout: timeout));
 
 /// Sends an HTTP GET request with the given headers to the given URL and
 /// returns a Future that completes to the body of the response as a list of
@@ -155,8 +173,10 @@ Future<String> read(Uri url, {Map<String, String>? headers}) =>
 ///
 /// For more fine-grained control over the request and response, use [Request]
 /// instead.
-Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.readBytes(url, headers: headers));
+Future<Uint8List> readBytes(Uri url,
+        {Map<String, String>? headers, Duration? timeout}) =>
+    _withClient(
+        (client) => client.readBytes(url, headers: headers, timeout: timeout));
 
 Future<T> _withClient<T>(Future<T> Function(Client) fn) async {
   var client = Client();

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -19,43 +19,63 @@ import 'streamed_response.dart';
 /// maybe [close], and then they get various convenience methods for free.
 abstract class BaseClient implements Client {
   @override
-  Future<Response> head(Uri url, {Map<String, String>? headers}) =>
-      _sendUnstreamed('HEAD', url, headers);
+  Future<Response> head(Uri url,
+          {Map<String, String>? headers, Duration? timeout}) =>
+      _sendUnstreamed('HEAD', url, headers, timeout: timeout);
 
   @override
-  Future<Response> get(Uri url, {Map<String, String>? headers}) =>
-      _sendUnstreamed('GET', url, headers);
+  Future<Response> get(Uri url,
+          {Map<String, String>? headers, Duration? timeout}) =>
+      _sendUnstreamed('GET', url, headers, timeout: timeout);
 
   @override
   Future<Response> post(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('POST', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          Duration? timeout}) =>
+      _sendUnstreamed('POST', url, headers,
+          body: body, encoding: encoding, timeout: timeout);
 
   @override
   Future<Response> put(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('PUT', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          Duration? timeout}) =>
+      _sendUnstreamed('PUT', url, headers,
+          body: body, encoding: encoding, timeout: timeout);
 
   @override
   Future<Response> patch(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('PATCH', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          Duration? timeout}) =>
+      _sendUnstreamed('PATCH', url, headers,
+          body: body, encoding: encoding, timeout: timeout);
 
   @override
   Future<Response> delete(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('DELETE', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          Duration? timeout}) =>
+      _sendUnstreamed('DELETE', url, headers,
+          body: body, encoding: encoding, timeout: timeout);
 
   @override
-  Future<String> read(Uri url, {Map<String, String>? headers}) async {
-    final response = await get(url, headers: headers);
+  Future<String> read(Uri url,
+      {Map<String, String>? headers, Duration? timeout}) async {
+    final response = await get(url, headers: headers, timeout: timeout);
     _checkResponseSuccess(url, response);
     return response.body;
   }
 
   @override
-  Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) async {
-    final response = await get(url, headers: headers);
+  Future<Uint8List> readBytes(Uri url,
+      {Map<String, String>? headers, Duration? timeout}) async {
+    final response = await get(url, headers: headers, timeout: timeout);
     _checkResponseSuccess(url, response);
     return response.bodyBytes;
   }
@@ -68,12 +88,12 @@ abstract class BaseClient implements Client {
   /// later point, or it could already be closed when it's returned. Any
   /// internal HTTP errors should be wrapped as [ClientException]s.
   @override
-  Future<StreamedResponse> send(BaseRequest request);
+  Future<StreamedResponse> send(BaseRequest request, {Duration? timeout});
 
   /// Sends a non-streaming [Request] and returns a non-streaming [Response].
   Future<Response> _sendUnstreamed(
       String method, Uri url, Map<String, String>? headers,
-      [body, Encoding? encoding]) async {
+      {dynamic body, Encoding? encoding, Duration? timeout}) async {
     var request = Request(method, url);
 
     if (headers != null) request.headers.addAll(headers);
@@ -90,7 +110,7 @@ abstract class BaseClient implements Client {
       }
     }
 
-    return Response.fromStream(await send(request));
+    return Response.fromStream(await send(request, timeout: timeout));
   }
 
   /// Throws an error if [response] is not successful.

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -84,7 +84,8 @@ abstract class BaseClient implements Client {
   /// later point, or it could already be closed when it's returned. Any
   /// internal HTTP errors should be wrapped as [ClientException]s.
   @override
-  Future<StreamedResponse> send(BaseRequest request, {Duration? timeout});
+  Future<StreamedResponse> send(BaseRequest request,
+      {Duration? contentTimeout});
 
   /// Sends a non-streaming [Request] and returns a non-streaming [Response].
   Future<Response> _sendUnstreamed(
@@ -110,7 +111,7 @@ abstract class BaseClient implements Client {
       }
     }
 
-    return Response.fromStream(await send(request, timeout: timeout));
+    return Response.fromStream(await send(request, contentTimeout: timeout));
   }
 
   /// Throws an error if [response] is not successful.

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -21,12 +21,12 @@ abstract class BaseClient implements Client {
   @override
   Future<Response> head(Uri url,
           {Map<String, String>? headers, Duration? timeout}) =>
-      _sendUnstreamed('HEAD', url, headers, timeout: timeout);
+      _sendUnstreamed('HEAD', url, headers, null, null, timeout);
 
   @override
   Future<Response> get(Uri url,
           {Map<String, String>? headers, Duration? timeout}) =>
-      _sendUnstreamed('GET', url, headers, timeout: timeout);
+      _sendUnstreamed('GET', url, headers, null, null, timeout);
 
   @override
   Future<Response> post(Uri url,
@@ -34,8 +34,7 @@ abstract class BaseClient implements Client {
           Object? body,
           Encoding? encoding,
           Duration? timeout}) =>
-      _sendUnstreamed('POST', url, headers,
-          body: body, encoding: encoding, timeout: timeout);
+      _sendUnstreamed('POST', url, headers, body, encoding, timeout);
 
   @override
   Future<Response> put(Uri url,
@@ -43,8 +42,7 @@ abstract class BaseClient implements Client {
           Object? body,
           Encoding? encoding,
           Duration? timeout}) =>
-      _sendUnstreamed('PUT', url, headers,
-          body: body, encoding: encoding, timeout: timeout);
+      _sendUnstreamed('PUT', url, headers, body, encoding, timeout);
 
   @override
   Future<Response> patch(Uri url,
@@ -52,8 +50,7 @@ abstract class BaseClient implements Client {
           Object? body,
           Encoding? encoding,
           Duration? timeout}) =>
-      _sendUnstreamed('PATCH', url, headers,
-          body: body, encoding: encoding, timeout: timeout);
+      _sendUnstreamed('PATCH', url, headers, body, encoding, timeout);
 
   @override
   Future<Response> delete(Uri url,
@@ -61,8 +58,7 @@ abstract class BaseClient implements Client {
           Object? body,
           Encoding? encoding,
           Duration? timeout}) =>
-      _sendUnstreamed('DELETE', url, headers,
-          body: body, encoding: encoding, timeout: timeout);
+      _sendUnstreamed('DELETE', url, headers, body, encoding, timeout);
 
   @override
   Future<String> read(Uri url,
@@ -92,8 +88,12 @@ abstract class BaseClient implements Client {
 
   /// Sends a non-streaming [Request] and returns a non-streaming [Response].
   Future<Response> _sendUnstreamed(
-      String method, Uri url, Map<String, String>? headers,
-      {dynamic body, Encoding? encoding, Duration? timeout}) async {
+      String method,
+      Uri url,
+      Map<String, String>? headers,
+      dynamic body,
+      Encoding? encoding,
+      Duration? timeout) async {
     var request = Request(method, url);
 
     if (headers != null) request.headers.addAll(headers);

--- a/lib/src/base_request.dart
+++ b/lib/src/base_request.dart
@@ -117,11 +117,11 @@ abstract class BaseRequest {
   /// the request is complete. If you're planning on making multiple requests to
   /// the same server, you should use a single [Client] for all of those
   /// requests.
-  Future<StreamedResponse> send() async {
+  Future<StreamedResponse> send({Duration? timeout}) async {
     var client = Client();
 
     try {
-      var response = await client.send(this);
+      var response = await client.send(this, timeout: timeout);
       var stream = onDone(response.stream, client.close);
       return StreamedResponse(ByteStream(stream), response.statusCode,
           contentLength: response.contentLength,

--- a/lib/src/base_request.dart
+++ b/lib/src/base_request.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:meta/meta.dart';
@@ -117,11 +118,18 @@ abstract class BaseRequest {
   /// the request is complete. If you're planning on making multiple requests to
   /// the same server, you should use a single [Client] for all of those
   /// requests.
-  Future<StreamedResponse> send({Duration? timeout}) async {
+  ///
+  /// If [contentTimeout] is not null the request will be aborted if it takes
+  /// longer than the given duration to receive the entire response. If the
+  /// timeout occurs before any reply is received from the server the returned
+  /// future will as an error with a [TimeoutException]. If the timout occurs
+  /// after the reply has been started but before the entire body has been read
+  /// the response stream will emit a [TimeoutException] and close.
+  Future<StreamedResponse> send({Duration? contentTimeout}) async {
     var client = Client();
 
     try {
-      var response = await client.send(this, timeout: timeout);
+      var response = await client.send(this, contentTimeout: contentTimeout);
       var stream = onDone(response.stream, client.close);
       return StreamedResponse(ByteStream(stream), response.statusCode,
           contentLength: response.contentLength,

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -62,6 +62,9 @@ class BrowserClient extends BaseClient {
     var bytes = await request.finalize().toBytes();
     var xhr = HttpRequest();
     _xhrs.add(xhr);
+    unawaited(completer.future.whenComplete(() {
+      _xhrs.remove(xhr);
+    }));
     xhr
       ..open(request.method, '${request.url}', async: true)
       ..responseType = 'arraybuffer'
@@ -83,7 +86,6 @@ class BrowserClient extends BaseClient {
           request: request,
           headers: xhr.responseHeaders,
           reasonPhrase: xhr.statusText));
-      _xhrs.remove(xhr);
     }));
 
     unawaited(xhr.onError.first.then((_) {
@@ -93,7 +95,6 @@ class BrowserClient extends BaseClient {
       completer.completeError(
           ClientException('XMLHttpRequest error.', request.url),
           StackTrace.current);
-      _xhrs.remove(xhr);
     }));
 
     xhr.send(bytes);

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -41,9 +41,10 @@ class BrowserClient extends BaseClient {
 
   /// Sends an HTTP request and asynchronously returns the response.
   @override
-  Future<StreamedResponse> send(BaseRequest request, {Duration? timeout}) {
+  Future<StreamedResponse> send(BaseRequest request,
+      {Duration? contentTimeout}) {
     final completer = Completer<StreamedResponse>();
-    _send(request, timeout, completer);
+    _send(request, contentTimeout, completer);
     return completer.future;
   }
 

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -60,9 +60,12 @@ class BrowserClient extends BaseClient {
     var bytes = await request.finalize().toBytes();
     var xhr = toAbort = HttpRequest();
     _xhrs.add(xhr);
-    unawaited(completer.future.whenComplete(() {
-      _xhrs.remove(xhr);
-    }));
+    unawaited(completer.future
+        .whenComplete(() {
+          _xhrs.remove(xhr);
+        })
+        .then<void>((_) {})
+        .catchError((_) {}));
     xhr
       ..open(request.method, '${request.url}', async: true)
       ..responseType = 'arraybuffer'

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -182,13 +182,14 @@ abstract class Client {
 
   /// Sends an HTTP request and asynchronously returns the response.
   ///
-  /// If [timeout] is not null the request will be aborted if it takes longer
-  /// than the given duration to complete. If the timeout occurs before any
-  /// reply is received from the server the returned future will as an error
-  /// with a [TimeoutException]. If the timout occurs after the reply has been
-  /// started but before the entire body has been read the response stream will
-  /// emit a [TimeoutException] and close.
-  Future<StreamedResponse> send(BaseRequest request, {Duration? timeout});
+  /// If [contentTimeout] is not null the request will be aborted if it takes
+  /// longer than the given duration to receive the entire response. If the
+  /// timeout occurs before any reply is received from the server the returned
+  /// future will as an error with a [TimeoutException]. If the timout occurs
+  /// after the reply has been started but before the entire body has been read
+  /// the response stream will emit a [TimeoutException] and close.
+  Future<StreamedResponse> send(BaseRequest request, {Duration?
+    contentTimeout});
 
   /// Closes the client and cleans up any resources associated with it.
   ///

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -33,11 +34,19 @@ abstract class Client {
 
   /// Sends an HTTP HEAD request with the given headers to the given URL.
   ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
+  ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> head(Uri url,
       {Map<String, String>? headers, Duration? timeout});
 
   /// Sends an HTTP GET request with the given headers to the given URL.
+  ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> get(Uri url,
@@ -59,6 +68,10 @@ abstract class Client {
   /// `"application/x-www-form-urlencoded"`; this cannot be overridden.
   ///
   /// [encoding] defaults to [utf8].
+  ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> post(Uri url,
@@ -84,6 +97,10 @@ abstract class Client {
   ///
   /// [encoding] defaults to [utf8].
   ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
+  ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> put(Uri url,
       {Map<String, String>? headers,
@@ -108,6 +125,10 @@ abstract class Client {
   ///
   /// [encoding] defaults to [utf8].
   ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
+  ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> patch(Uri url,
       {Map<String, String>? headers,
@@ -116,6 +137,10 @@ abstract class Client {
       Duration? timeout});
 
   /// Sends an HTTP DELETE request with the given headers to the given URL.
+  ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> delete(Uri url,
@@ -130,6 +155,10 @@ abstract class Client {
   /// The Future will emit a [ClientException] if the response doesn't have a
   /// success status code.
   ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
+  ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
   Future<String> read(Uri url,
@@ -142,12 +171,23 @@ abstract class Client {
   /// The Future will emit a [ClientException] if the response doesn't have a
   /// success status code.
   ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete, and the returned future will complete
+  /// as an error with a [TimeoutException].
+  ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
   Future<Uint8List> readBytes(Uri url,
       {Map<String, String>? headers, Duration? timeout});
 
   /// Sends an HTTP request and asynchronously returns the response.
+  ///
+  /// If [timeout] is not null the request will be aborted if it takes longer
+  /// than the given duration to complete. If the timeout occurs before any
+  /// reply is received from the server the returned future will as an error
+  /// with a [TimeoutException]. If the timout occurs after the reply has been
+  /// started but before the entire body has been read the response stream will
+  /// emit a [TimeoutException] and close.
   Future<StreamedResponse> send(BaseRequest request, {Duration? timeout});
 
   /// Closes the client and cleans up any resources associated with it.

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -34,12 +34,14 @@ abstract class Client {
   /// Sends an HTTP HEAD request with the given headers to the given URL.
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> head(Uri url, {Map<String, String>? headers});
+  Future<Response> head(Uri url,
+      {Map<String, String>? headers, Duration? timeout});
 
   /// Sends an HTTP GET request with the given headers to the given URL.
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> get(Uri url, {Map<String, String>? headers});
+  Future<Response> get(Uri url,
+      {Map<String, String>? headers, Duration? timeout});
 
   /// Sends an HTTP POST request with the given headers and body to the given
   /// URL.
@@ -60,7 +62,10 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> post(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      Object? body,
+      Encoding? encoding,
+      Duration? timeout});
 
   /// Sends an HTTP PUT request with the given headers and body to the given
   /// URL.
@@ -81,7 +86,10 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> put(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      Object? body,
+      Encoding? encoding,
+      Duration? timeout});
 
   /// Sends an HTTP PATCH request with the given headers and body to the given
   /// URL.
@@ -102,13 +110,19 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> patch(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      Object? body,
+      Encoding? encoding,
+      Duration? timeout});
 
   /// Sends an HTTP DELETE request with the given headers to the given URL.
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> delete(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      Object? body,
+      Encoding? encoding,
+      Duration? timeout});
 
   /// Sends an HTTP GET request with the given headers to the given URL and
   /// returns a Future that completes to the body of the response as a String.
@@ -118,7 +132,8 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
-  Future<String> read(Uri url, {Map<String, String>? headers});
+  Future<String> read(Uri url,
+      {Map<String, String>? headers, Duration? timeout});
 
   /// Sends an HTTP GET request with the given headers to the given URL and
   /// returns a Future that completes to the body of the response as a list of
@@ -129,10 +144,11 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
-  Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers});
+  Future<Uint8List> readBytes(Uri url,
+      {Map<String, String>? headers, Duration? timeout});
 
   /// Sends an HTTP request and asynchronously returns the response.
-  Future<StreamedResponse> send(BaseRequest request);
+  Future<StreamedResponse> send(BaseRequest request, {Duration? timeout});
 
   /// Closes the client and cleans up any resources associated with it.
   ///

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'base_client.dart';
@@ -23,32 +24,68 @@ class IOClient extends BaseClient {
 
   /// Sends an HTTP request and asynchronously returns the response.
   @override
-  Future<IOStreamedResponse> send(BaseRequest request) async {
+  Future<IOStreamedResponse> send(BaseRequest request, {Duration? timeout}) {
+    final completer = Completer<IOStreamedResponse>();
+    _send(request, timeout, completer);
+    return completer.future;
+  }
+
+  Future<void> _send(BaseRequest request, Duration? timeout,
+      Completer<IOStreamedResponse> completer) async {
     var stream = request.finalize();
 
+    Timer? timer;
+    late void Function() onTimeout;
+    if (timeout != null) {
+      timer = Timer(timeout, () {
+        onTimeout();
+      });
+      onTimeout = () {
+        completer.completeError(TimeoutException('Request aborted', timeout));
+      };
+    }
     try {
       var ioRequest = (await _inner!.openUrl(request.method, request.url))
         ..followRedirects = request.followRedirects
         ..maxRedirects = request.maxRedirects
         ..contentLength = (request.contentLength ?? -1)
         ..persistentConnection = request.persistentConnection;
+      if (completer.isCompleted) return;
       request.headers.forEach((name, value) {
         ioRequest.headers.set(name, value);
       });
 
+      if (timeout != null) {
+        onTimeout = () {
+          ioRequest.abort();
+          completer.completeError(TimeoutException('Request aborted', timeout));
+        };
+      }
+
       var response = await stream.pipe(ioRequest) as HttpClientResponse;
+      if (completer.isCompleted) return;
 
       var headers = <String, String>{};
       response.headers.forEach((key, values) {
         headers[key] = values.join(',');
       });
+      var responseStream = response.handleError((error) {
+        final httpException = error as HttpException;
+        throw ClientException(httpException.message, httpException.uri);
+      }, test: (error) => error is HttpException).transform<List<int>>(
+          StreamTransformer.fromHandlers(handleDone: (sink) {
+        timer?.cancel();
+        sink.close();
+      }));
 
-      return IOStreamedResponse(
-          response.handleError((error) {
-            final httpException = error as HttpException;
-            throw ClientException(httpException.message, httpException.uri);
-          }, test: (error) => error is HttpException),
-          response.statusCode,
+      if (timeout != null) {
+        onTimeout = () {
+          // TODO, is this necessary? How will it surface?
+          response.detachSocket().then((socket) => socket.destroy());
+        };
+      }
+
+      completer.complete(IOStreamedResponse(responseStream, response.statusCode,
           contentLength:
               response.contentLength == -1 ? null : response.contentLength,
           request: request,
@@ -56,9 +93,13 @@ class IOClient extends BaseClient {
           isRedirect: response.isRedirect,
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase,
-          inner: response);
+          inner: response));
     } on HttpException catch (error) {
-      throw ClientException(error.message, error.uri);
+      if (completer.isCompleted) return;
+      completer.completeError(ClientException(error.message, error.uri));
+    } catch (error, stackTrace) {
+      if (completer.isCompleted) return;
+      completer.completeError(error, stackTrace);
     }
   }
 

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -35,14 +35,14 @@ class IOClient extends BaseClient {
     var stream = request.finalize();
 
     Timer? timer;
-    late void Function() onTimeout;
+    void Function() onTimeout;
     if (timeout != null) {
-      timer = Timer(timeout, () {
-        onTimeout();
-      });
       onTimeout = () {
         completer.completeError(TimeoutException('Request aborted', timeout));
       };
+      timer = Timer(timeout, () {
+        onTimeout();
+      });
     }
     try {
       var ioRequest = (await _inner!.openUrl(request.method, request.url))

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -65,7 +65,8 @@ class MockClient extends BaseClient {
         });
 
   @override
-  Future<StreamedResponse> send(BaseRequest request) async {
+  Future<StreamedResponse> send(BaseRequest request,
+      {Duration? timeout}) async {
     var bodyStream = request.finalize();
     return await _handler(request, bodyStream);
   }

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -66,7 +66,7 @@ class MockClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request,
-      {Duration? timeout}) async {
+      {Duration? contentTimeout}) async {
     var bodyStream = request.finalize();
     return await _handler(request, bodyStream);
   }


### PR DESCRIPTION
Wire up a timer to perform the appropriate type of aborting and resource
cleanup for each client. Handles canceling the timer when the request
completes.