### PR TITLE
Prepare to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,9 @@
-## 0.13.0-nullsafety-dev
+## 0.13.0-nullsafety.0
 
-Pre-release for the null safety migration of this package.
-
-Note that 0.12.3 may not be the final stable null safety release version, we
-reserve the right to release it as a 0.13.0 breaking change.
-
-This release will be pinned to only allow pre-release sdk versions starting from
-2.10.0-2.0.dev, which is the first version where this package will appear in the
-null safety allow list.
-
+* Migrate to null safety.
 * Add `const` constructor to `ByteStream`.
 * Migrate `BrowserClient` from `blob` to `arraybuffer`.
-* **BREAKING** All APIs which previously allowed a `String` or `Uri` to be
+* **Breaking** All APIs which previously allowed a `String` or `Uri` to be
   passed now require a `Uri`.
 * **Breaking** Added a `body` and `encoding` argument to `Client.delete`. This
   is only breaking for implementations which override that method.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   pedantic: ^1.10.0-nullsafety
 
 dev_dependencies:
-  test: ^1.16.0-nullsafety.4
   shelf: any
+  test: ^1.16.0-nullsafety.4
 
 dependency_overrides:
   shelf:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
 
 dev_dependencies:
   test: ^1.16.0-nullsafety.4
+  shelf: any
 
 dependency_overrides:
-  http_parser: ^4.0.0-nullsafety
-  # Because pkg:test does not support pkg:http ^0.13.0
-  test: ^1.16.0-nullsafety.5
+  shelf:
+    git: git://github.com/dart-lang/shelf.git


### PR DESCRIPTION
- Fix changelog version and remove wording about the allow list which
  does not apply anymore.
- Drop overrides on `test` and `http_parser`. Add dev dependency and
  override on `shelf` which is the sole cause of an impossible solve.
  This will be resolved once shelf is published and `test` allows it
  from it's constraints.