### PR TITLE
meta support null safe

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   http_parser: ^4.0.0
-  meta: ^1.3.0
+  meta: ^1.3.0-nullsafety.6
   path: ^1.8.0
   pedantic: ^1.10.0
 


### PR DESCRIPTION
flutter_test from sdk depends on meta 1.3.0-nullsafety.6.