### PR TITLE
Remove expectation that GET without a body has content-length 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.13.3-dev
+
 ## 0.13.2
 
 * Add `package:http/retry.dart` with `RetryClient`. This is the same

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.13.2
+version: 0.13.3-dev
 homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 

--- a/test/io/http_test.dart
+++ b/test/io/http_test.dart
@@ -30,17 +30,16 @@ void main() {
       expect(response.statusCode, equals(200));
       expect(
           response.body,
-          parse(equals({
-            'method': 'GET',
-            'path': '/',
-            'headers': {
-              'content-length': ['0'],
-              'accept-encoding': ['gzip'],
-              'user-agent': ['Dart'],
-              'x-random-header': ['Value'],
-              'x-other-header': ['Other Value']
-            },
-          })));
+          parse(allOf(
+              containsPair('method', 'GET'),
+              containsPair('path', '/'),
+              containsPair(
+                  'headers',
+                  allOf(
+                      containsPair('accept-encoding', ['gzip']),
+                      containsPair('user-agent', ['Dart']),
+                      containsPair('x-random-header', ['Value']),
+                      containsPair('x-other-header', ['Other Value']))))));
     });
 
     test('post', () async {
@@ -397,17 +396,16 @@ void main() {
       });
       expect(
           response,
-          parse(equals({
-            'method': 'GET',
-            'path': '/',
-            'headers': {
-              'content-length': ['0'],
-              'accept-encoding': ['gzip'],
-              'user-agent': ['Dart'],
-              'x-random-header': ['Value'],
-              'x-other-header': ['Other Value']
-            },
-          })));
+          parse(allOf(
+              containsPair('method', 'GET'),
+              containsPair('path', '/'),
+              containsPair(
+                  'headers',
+                  allOf(
+                      containsPair('accept-encoding', ['gzip']),
+                      containsPair('user-agent', ['Dart']),
+                      containsPair('x-random-header', ['Value']),
+                      containsPair('x-other-header', ['Other Value']))))));
     });
 
     test('read throws an error for a 4** status code', () {
@@ -423,17 +421,16 @@ void main() {
 
       expect(
           String.fromCharCodes(bytes),
-          parse(equals({
-            'method': 'GET',
-            'path': '/',
-            'headers': {
-              'content-length': ['0'],
-              'accept-encoding': ['gzip'],
-              'user-agent': ['Dart'],
-              'x-random-header': ['Value'],
-              'x-other-header': ['Other Value']
-            },
-          })));
+          parse(allOf(
+              containsPair('method', 'GET'),
+              containsPair('path', '/'),
+              containsPair(
+                  'headers',
+                  allOf(
+                      containsPair('accept-encoding', ['gzip']),
+                      containsPair('user-agent', ['Dart']),
+                      containsPair('x-random-header', ['Value']),
+                      containsPair('x-other-header', ['Other Value']))))));
     });
 
     test('readBytes throws an error for a 4** status code', () {


### PR DESCRIPTION
See https://dart-review.googlesource.com/c/sdk/+/194881 that is going to remove content-length:0 header for GET and HEAD requests that has no body.