### PR TITLE
Fix example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var response = await http.post(url, body: {'name': 'doodle', 'color': 'blue'});
 print('Response status: ${response.statusCode}');
 print('Response body: ${response.body}');
 
-print(await http.read('https://example.com/foobar.txt'));
+print(await http.read(Uri.parse('https://example.com/foobar.txt')));
 ```
 
 If you're making multiple requests to the same server, you can keep open a
@@ -84,7 +84,7 @@ import 'package:http/retry.dart';
 Future<void> main() async {
   final client = RetryClient(http.Client());
   try {
-    print(await client.read('http://example.org'));
+    print(await client.read(Uri.parse('http://example.org')));
   } finally {
     client.close();
   }


### PR DESCRIPTION
Adding missing Uri.parse( ) to statements