### PR TITLE
Remove expectation that DELETE without a body has 'content-length:0' header

### DIFF
--- a/test/io/http_test.dart
+++ b/test/io/http_test.dart
@@ -375,17 +375,16 @@ void main() {
       expect(response.statusCode, equals(200));
       expect(
           response.body,
-          parse(equals({
-            'method': 'DELETE',
-            'path': '/',
-            'headers': {
-              'content-length': ['0'],
-              'accept-encoding': ['gzip'],
-              'user-agent': ['Dart'],
-              'x-random-header': ['Value'],
-              'x-other-header': ['Other Value']
-            }
-          })));
+          parse(allOf(
+              containsPair('method', 'DELETE'),
+              containsPair('path', '/'),
+              containsPair(
+                  'headers',
+                  allOf(
+                      containsPair('accept-encoding', ['gzip']),
+                      containsPair('user-agent', ['Dart']),
+                      containsPair('x-random-header', ['Value']),
+                      containsPair('x-other-header', ['Other Value']))))));
     });
 
     test('read', () async {


### PR DESCRIPTION
This is follow-up to ca730a3415c158035ef77001fccc916e901a0556.

See https://dart-review.googlesource.com/c/sdk/+/194881