### PR TITLE
Add onSendProgress callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.13.4-dev
 
+* Add `onSendProgress` callback
+
 ## 0.13.3
 
 * Validate that the `method` parameter of BaseRequest is a valid "token".

--- a/lib/http.dart
+++ b/lib/http.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 
 import 'src/client.dart';
 import 'src/exception.dart';
+import 'src/progress.dart';
 import 'src/request.dart';
 import 'src/response.dart';
 import 'src/streamed_request.dart';
@@ -20,6 +21,7 @@ export 'src/client.dart';
 export 'src/exception.dart';
 export 'src/multipart_file.dart';
 export 'src/multipart_request.dart';
+export 'src/progress.dart';
 export 'src/request.dart';
 export 'src/response.dart';
 export 'src/streamed_request.dart';
@@ -61,12 +63,25 @@ Future<Response> get(Uri url, {Map<String, String>? headers}) =>
 ///
 /// [encoding] defaults to [utf8].
 ///
+/// If [onSendProgress] is provided it will be called to indicate
+/// the upload progress
+///
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
-Future<Response> post(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.post(url, headers: headers, body: body, encoding: encoding));
+Future<Response> post(
+  Uri url, {
+  Map<String, String>? headers,
+  Object? body,
+  Encoding? encoding,
+  Progress? onSendProgress,
+}) =>
+    _withClient((client) => client.post(
+          url,
+          headers: headers,
+          body: body,
+          encoding: encoding,
+          onSendProgress: onSendProgress,
+        ));
 
 /// Sends an HTTP PUT request with the given headers and body to the given URL.
 ///
@@ -84,12 +99,25 @@ Future<Response> post(Uri url,
 ///
 /// [encoding] defaults to [utf8].
 ///
+/// If [onSendProgress] is provided it will be called to indicate
+/// the upload progress
+///
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
-Future<Response> put(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.put(url, headers: headers, body: body, encoding: encoding));
+Future<Response> put(
+  Uri url, {
+  Map<String, String>? headers,
+  Object? body,
+  Encoding? encoding,
+  Progress? onSendProgress,
+}) =>
+    _withClient((client) => client.put(
+          url,
+          headers: headers,
+          body: body,
+          encoding: encoding,
+          onSendProgress: onSendProgress,
+        ));
 
 /// Sends an HTTP PATCH request with the given headers and body to the given
 /// URL.
@@ -108,12 +136,25 @@ Future<Response> put(Uri url,
 ///
 /// [encoding] defaults to [utf8].
 ///
+/// If [onSendProgress] is provided it will be called to indicate
+/// the upload progress
+///
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
-Future<Response> patch(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.patch(url, headers: headers, body: body, encoding: encoding));
+Future<Response> patch(
+  Uri url, {
+  Map<String, String>? headers,
+  Object? body,
+  Encoding? encoding,
+  Progress? onSendProgress,
+}) =>
+    _withClient((client) => client.patch(
+          url,
+          headers: headers,
+          body: body,
+          encoding: encoding,
+          onSendProgress: onSendProgress,
+        ));
 
 /// Sends an HTTP DELETE request with the given headers to the given URL.
 ///
@@ -121,11 +162,24 @@ Future<Response> patch(Uri url,
 /// the request is complete. If you're planning on making multiple requests to
 /// the same server, you should use a single [Client] for all of those requests.
 ///
+/// If [onSendProgress] is provided it will be called to indicate
+/// the upload progress
+///
 /// For more fine-grained control over the request, use [Request] instead.
-Future<Response> delete(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.delete(url, headers: headers, body: body, encoding: encoding));
+Future<Response> delete(
+  Uri url, {
+  Map<String, String>? headers,
+  Object? body,
+  Encoding? encoding,
+  Progress? onSendProgress,
+}) =>
+    _withClient((client) => client.delete(
+          url,
+          headers: headers,
+          body: body,
+          encoding: encoding,
+          onSendProgress: onSendProgress,
+        ));
 
 /// Sends an HTTP GET request with the given headers to the given URL and
 /// returns a Future that completes to the body of the response as a [String].

--- a/lib/retry.dart
+++ b/lib/retry.dart
@@ -99,14 +99,20 @@ class RetryClient extends BaseClient {
         );
 
   @override
-  Future<StreamedResponse> send(BaseRequest request) async {
+  Future<StreamedResponse> send(
+    BaseRequest request, {
+    Progress? onSendProgress,
+  }) async {
     final splitter = StreamSplitter(request.finalize());
 
     var i = 0;
     for (;;) {
       StreamedResponse? response;
       try {
-        response = await _inner.send(_copyRequest(request, splitter.split()));
+        response = await _inner.send(
+          _copyRequest(request, splitter.split()),
+          onSendProgress: onSendProgress,
+        );
       } catch (error, stackTrace) {
         if (i == _retries || !_whenError(error, stackTrace)) rethrow;
       }

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -9,6 +9,7 @@ import 'base_request.dart';
 import 'byte_stream.dart';
 import 'client.dart';
 import 'exception.dart';
+import 'progress.dart';
 import 'request.dart';
 import 'response.dart';
 import 'streamed_response.dart';
@@ -27,24 +28,72 @@ abstract class BaseClient implements Client {
       _sendUnstreamed('GET', url, headers);
 
   @override
-  Future<Response> post(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('POST', url, headers, body, encoding);
+  Future<Response> post(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  }) =>
+      _sendUnstreamed(
+        'POST',
+        url,
+        headers,
+        body,
+        encoding,
+        onSendProgress,
+      );
 
   @override
-  Future<Response> put(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('PUT', url, headers, body, encoding);
+  Future<Response> put(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  }) =>
+      _sendUnstreamed(
+        'PUT',
+        url,
+        headers,
+        body,
+        encoding,
+        onSendProgress,
+      );
 
   @override
-  Future<Response> patch(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('PATCH', url, headers, body, encoding);
+  Future<Response> patch(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  }) =>
+      _sendUnstreamed(
+        'PATCH',
+        url,
+        headers,
+        body,
+        encoding,
+        onSendProgress,
+      );
 
   @override
-  Future<Response> delete(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('DELETE', url, headers, body, encoding);
+  Future<Response> delete(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  }) =>
+      _sendUnstreamed(
+        'DELETE',
+        url,
+        headers,
+        body,
+        encoding,
+        onSendProgress,
+      );
 
   @override
   Future<String> read(Uri url, {Map<String, String>? headers}) async {
@@ -68,12 +117,20 @@ abstract class BaseClient implements Client {
   /// later point, or it could already be closed when it's returned. Any
   /// internal HTTP errors should be wrapped as [ClientException]s.
   @override
-  Future<StreamedResponse> send(BaseRequest request);
+  Future<StreamedResponse> send(
+    BaseRequest request, {
+    Progress? onSendProgress,
+  });
 
   /// Sends a non-streaming [Request] and returns a non-streaming [Response].
   Future<Response> _sendUnstreamed(
-      String method, Uri url, Map<String, String>? headers,
-      [body, Encoding? encoding]) async {
+    String method,
+    Uri url,
+    Map<String, String>? headers, [
+    body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  ]) async {
     var request = Request(method, url);
 
     if (headers != null) request.headers.addAll(headers);
@@ -90,7 +147,10 @@ abstract class BaseClient implements Client {
       }
     }
 
-    return Response.fromStream(await send(request));
+    return Response.fromStream(await send(
+      request,
+      onSendProgress: onSendProgress,
+    ));
   }
 
   /// Throws an error if [response] is not successful.

--- a/lib/src/base_request.dart
+++ b/lib/src/base_request.dart
@@ -11,6 +11,7 @@ import 'base_client.dart';
 import 'base_response.dart';
 import 'byte_stream.dart';
 import 'client.dart';
+import 'progress.dart';
 import 'streamed_response.dart';
 import 'utils.dart';
 
@@ -26,6 +27,9 @@ abstract class BaseRequest {
   /// Most commonly "GET" or "POST", less commonly "HEAD", "PUT", or "DELETE".
   /// Non-standard method names are also supported.
   final String method;
+
+  /// The callback to call for data send progress.
+  Progress? onSendProgress;
 
   /// The URL to which the request will be sent.
   final Uri url;
@@ -130,7 +134,10 @@ abstract class BaseRequest {
     var client = Client();
 
     try {
-      var response = await client.send(this);
+      var response = await client.send(
+        this,
+        onSendProgress: onSendProgress,
+      );
       var stream = onDone(response.stream, client.close);
       return StreamedResponse(ByteStream(stream), response.statusCode,
           contentLength: response.contentLength,

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -53,6 +53,18 @@ class BrowserClient extends BaseClient {
       ..open(request.method, '${request.url}', async: true)
       ..responseType = 'arraybuffer'
       ..withCredentials = withCredentials;
+
+    if (onSendProgress != null) {
+      xhr.upload.addEventListener('progress', (event) {
+        if (event is ProgressEvent && event.lengthComputable) {
+          onSendProgress(
+            event.loaded,
+            event.total,
+          );
+        }
+      });
+    }
+
     request.headers.forEach(xhr.setRequestHeader);
 
     var completer = Completer<StreamedResponse>();

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -12,6 +12,7 @@ import 'base_client.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';
 import 'exception.dart';
+import 'progress.dart';
 import 'streamed_response.dart';
 
 /// Create a [BrowserClient].
@@ -41,7 +42,10 @@ class BrowserClient extends BaseClient {
 
   /// Sends an HTTP request and asynchronously returns the response.
   @override
-  Future<StreamedResponse> send(BaseRequest request) async {
+  Future<StreamedResponse> send(
+    BaseRequest request, {
+    Progress? onSendProgress,
+  }) async {
     var bytes = await request.finalize().toBytes();
     var xhr = HttpRequest();
     _xhrs.add(xhr);

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -11,6 +11,7 @@ import 'client_stub.dart'
     if (dart.library.html) 'browser_client.dart'
     if (dart.library.io) 'io_client.dart';
 import 'exception.dart';
+import 'progress.dart';
 import 'response.dart';
 import 'streamed_response.dart';
 
@@ -58,9 +59,17 @@ abstract class Client {
   ///
   /// [encoding] defaults to [utf8].
   ///
+  /// If [onSendProgress] is provided it will be called to indicate
+  /// the upload progress
+  ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> post(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+  Future<Response> post(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  });
 
   /// Sends an HTTP PUT request with the given headers and body to the given
   /// URL.
@@ -79,9 +88,17 @@ abstract class Client {
   ///
   /// [encoding] defaults to [utf8].
   ///
+  /// If [onSendProgress] is provided it will be called to indicate
+  /// the upload progress
+  ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> put(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+  Future<Response> put(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  });
 
   /// Sends an HTTP PATCH request with the given headers and body to the given
   /// URL.
@@ -100,15 +117,31 @@ abstract class Client {
   ///
   /// [encoding] defaults to [utf8].
   ///
+  /// If [onSendProgress] is provided it will be called to indicate
+  /// the upload progress
+  ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> patch(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+  Future<Response> patch(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  });
 
   /// Sends an HTTP DELETE request with the given headers to the given URL.
   ///
+  /// If [onSendProgress] is provided it will be called to indicate
+  /// the upload progress
+  ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> delete(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+  Future<Response> delete(
+    Uri url, {
+    Map<String, String>? headers,
+    Object? body,
+    Encoding? encoding,
+    Progress? onSendProgress,
+  });
 
   /// Sends an HTTP GET request with the given headers to the given URL and
   /// returns a Future that completes to the body of the response as a String.
@@ -132,7 +165,14 @@ abstract class Client {
   Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers});
 
   /// Sends an HTTP request and asynchronously returns the response.
-  Future<StreamedResponse> send(BaseRequest request);
+  ///
+  /// If [onSendProgress] is provided it will be called to indicate
+  /// the upload progress
+  ///
+  Future<StreamedResponse> send(
+    BaseRequest request, {
+    Progress? onSendProgress,
+  });
 
   /// Closes the client and cleans up any resources associated with it.
   ///

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -40,7 +40,24 @@ class IOClient extends BaseClient {
         ioRequest.headers.set(name, value);
       });
 
-      var response = await stream.pipe(ioRequest) as HttpClientResponse;
+      HttpClientResponse response;
+      if (onSendProgress != null) {
+        var loaded = 0;
+        onSendProgress(loaded, request.contentLength);
+
+        await ioRequest.addStream(
+          stream.map(
+            (chunk) {
+              loaded += chunk.length;
+              onSendProgress(loaded, request.contentLength);
+              return chunk;
+            },
+          ),
+        );
+        response = await ioRequest.close();
+      } else {
+        response = await stream.pipe(ioRequest) as HttpClientResponse;
+      }
 
       var headers = <String, String>{};
       response.headers.forEach((key, values) {

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -8,6 +8,7 @@ import 'base_client.dart';
 import 'base_request.dart';
 import 'exception.dart';
 import 'io_streamed_response.dart';
+import 'progress.dart';
 
 /// Create an [IOClient].
 ///
@@ -23,7 +24,10 @@ class IOClient extends BaseClient {
 
   /// Sends an HTTP request and asynchronously returns the response.
   @override
-  Future<IOStreamedResponse> send(BaseRequest request) async {
+  Future<IOStreamedResponse> send(
+    BaseRequest request, {
+    Progress? onSendProgress,
+  }) async {
     var stream = request.finalize();
 
     try {

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -5,6 +5,7 @@
 import 'base_client.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';
+import 'progress.dart';
 import 'request.dart';
 import 'response.dart';
 import 'streamed_request.dart';
@@ -65,7 +66,10 @@ class MockClient extends BaseClient {
         });
 
   @override
-  Future<StreamedResponse> send(BaseRequest request) async {
+  Future<StreamedResponse> send(
+    BaseRequest request, {
+    Progress? onSendProgress,
+  }) async {
     var bodyStream = request.finalize();
     return await _handler(request, bodyStream);
   }

--- a/lib/src/progress.dart
+++ b/lib/src/progress.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Callback function for progress data.
+///
+typedef Progress = void Function(int? loaded, int? total);


### PR DESCRIPTION
This fixes the upload part of https://github.com/dart-lang/http/issues/465 

I had also tried to include the download progress, but that did not work as expected.
And it is why easier to do this while consuming the response stream.