### PR TITLE
Fixing null check exception in io_client.dart (#581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.13.4-dev
 
+* Throw a more useful error when a client is used after it has been closed.
+
 ## 0.13.3
 
 * Validate that the `method` parameter of BaseRequest is a valid "token".

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -26,8 +26,7 @@ class IOClient extends BaseClient {
   Future<IOStreamedResponse> send(BaseRequest request) async {
     if (_inner == null) {
       throw ClientException(
-          "HTTP send request failed, can't send data after client got closed.",
-          request.url);
+          'HTTP request failed. Client is already closed.', request.url);
     }
 
     var stream = request.finalize();

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -24,6 +24,12 @@ class IOClient extends BaseClient {
   /// Sends an HTTP request and asynchronously returns the response.
   @override
   Future<IOStreamedResponse> send(BaseRequest request) async {
+    if (_inner == null) {
+      throw ClientException(
+          "HTTP send request failed, can't send data after client got closed.",
+          request.url);
+    }
+
     var stream = request.finalize();
 
     try {


### PR DESCRIPTION
 Throw exception for IOClient when trying to send data and HttpClient is null (#581).

