### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,8 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   strong-mode:
     implicit-casts: false
-  enable-experiment:
-  - non-nullable
 
 linter:
   rules:

--- a/lib/src/browser_client.dart
+++ b/lib/src/browser_client.dart
@@ -6,13 +6,12 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';
 
-import 'package:pedantic/pedantic.dart' show unawaited;
-
 import 'base_client.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';
 import 'exception.dart';
 import 'streamed_response.dart';
+import 'utils.dart' show unawaited;
 
 /// Create a [BrowserClient].
 ///

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -74,3 +74,6 @@ Stream<T> onDone<T>(Stream<T> stream, void Function() onDone) =>
       sink.close();
       onDone();
     }));
+
+// TODO: Remove after Dart 2.14 is stable
+void unawaited<T>(Future<T> future) {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,9 @@ dependencies:
   http_parser: ^4.0.0
   meta: ^1.3.0
   path: ^1.8.0
-  pedantic: ^1.10.0
 
 dev_dependencies:
   fake_async: ^1.2.0
+  lints: ^1.0.0
   shelf: ^1.1.0
   test: ^1.16.0

--- a/test/io/utils.dart
+++ b/test/io/utils.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 
 import 'package:http/http.dart';
 import 'package:http/src/utils.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 export '../utils.dart';

--- a/test/response_test.dart
+++ b/test/response_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:http/http.dart' as http;
-import 'package:pedantic/pedantic.dart';
+import 'package:http/src/utils.dart' show unawaited;
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
Add a local copy of `unawaited` until Dart 2.14 is stable.