### PR TITLE
Request cancellation/abort through cancellation-token

### DIFF
--- a/lib/http.dart
+++ b/lib/http.dart
@@ -6,6 +6,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'src/cancelation_token.dart';
 import 'src/client.dart';
 import 'src/exception.dart';
 import 'src/request.dart';
@@ -16,6 +17,7 @@ export 'src/base_client.dart';
 export 'src/base_request.dart';
 export 'src/base_response.dart';
 export 'src/byte_stream.dart';
+export 'src/cancelation_token.dart';
 export 'src/client.dart';
 export 'src/exception.dart';
 export 'src/multipart_file.dart';
@@ -32,8 +34,10 @@ export 'src/streamed_response.dart';
 /// the same server, you should use a single [Client] for all of those requests.
 ///
 /// For more fine-grained control over the request, use [Request] instead.
-Future<Response> head(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.head(url, headers: headers));
+Future<Response> head(Uri url,
+        {Map<String, String>? headers, CancellationToken? cancellationToken}) =>
+    _withClient((client) => client.head(url,
+        headers: headers, cancellationToken: cancellationToken));
 
 /// Sends an HTTP GET request with the given headers to the given URL.
 ///
@@ -42,8 +46,10 @@ Future<Response> head(Uri url, {Map<String, String>? headers}) =>
 /// the same server, you should use a single [Client] for all of those requests.
 ///
 /// For more fine-grained control over the request, use [Request] instead.
-Future<Response> get(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.get(url, headers: headers));
+Future<Response> get(Uri url,
+        {Map<String, String>? headers, CancellationToken? cancellationToken}) =>
+    _withClient((client) => client.get(url,
+        headers: headers, cancellationToken: cancellationToken));
 
 /// Sends an HTTP POST request with the given headers and body to the given URL.
 ///
@@ -64,9 +70,15 @@ Future<Response> get(Uri url, {Map<String, String>? headers}) =>
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> post(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.post(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        CancellationToken? cancellationToken,
+        Object? body,
+        Encoding? encoding}) =>
+    _withClient((client) => client.post(url,
+        headers: headers,
+        cancellationToken: cancellationToken,
+        body: body,
+        encoding: encoding));
 
 /// Sends an HTTP PUT request with the given headers and body to the given URL.
 ///
@@ -87,9 +99,15 @@ Future<Response> post(Uri url,
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> put(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.put(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        CancellationToken? cancellationToken,
+        Object? body,
+        Encoding? encoding}) =>
+    _withClient((client) => client.put(url,
+        headers: headers,
+        cancellationToken: cancellationToken,
+        body: body,
+        encoding: encoding));
 
 /// Sends an HTTP PATCH request with the given headers and body to the given
 /// URL.
@@ -111,9 +129,15 @@ Future<Response> put(Uri url,
 /// For more fine-grained control over the request, use [Request] or
 /// [StreamedRequest] instead.
 Future<Response> patch(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.patch(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        CancellationToken? cancellationToken,
+        Object? body,
+        Encoding? encoding}) =>
+    _withClient((client) => client.patch(url,
+        headers: headers,
+        cancellationToken: cancellationToken,
+        body: body,
+        encoding: encoding));
 
 /// Sends an HTTP DELETE request with the given headers to the given URL.
 ///
@@ -123,9 +147,15 @@ Future<Response> patch(Uri url,
 ///
 /// For more fine-grained control over the request, use [Request] instead.
 Future<Response> delete(Uri url,
-        {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-    _withClient((client) =>
-        client.delete(url, headers: headers, body: body, encoding: encoding));
+        {Map<String, String>? headers,
+        CancellationToken? cancellationToken,
+        Object? body,
+        Encoding? encoding}) =>
+    _withClient((client) => client.delete(url,
+        headers: headers,
+        cancellationToken: cancellationToken,
+        body: body,
+        encoding: encoding));
 
 /// Sends an HTTP GET request with the given headers to the given URL and
 /// returns a Future that completes to the body of the response as a [String].
@@ -139,8 +169,10 @@ Future<Response> delete(Uri url,
 ///
 /// For more fine-grained control over the request and response, use [Request]
 /// instead.
-Future<String> read(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.read(url, headers: headers));
+Future<String> read(Uri url,
+        {Map<String, String>? headers, CancellationToken? cancellationToken}) =>
+    _withClient((client) => client.read(url,
+        headers: headers, cancellationToken: cancellationToken));
 
 /// Sends an HTTP GET request with the given headers to the given URL and
 /// returns a Future that completes to the body of the response as a list of
@@ -155,8 +187,10 @@ Future<String> read(Uri url, {Map<String, String>? headers}) =>
 ///
 /// For more fine-grained control over the request and response, use [Request]
 /// instead.
-Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) =>
-    _withClient((client) => client.readBytes(url, headers: headers));
+Future<Uint8List> readBytes(Uri url,
+        {Map<String, String>? headers, CancellationToken? cancellationToken}) =>
+    _withClient((client) => client.readBytes(url,
+        headers: headers, cancellationToken: cancellationToken));
 
 Future<T> _withClient<T>(Future<T> Function(Client) fn) async {
   var client = Client();

--- a/lib/retry.dart
+++ b/lib/retry.dart
@@ -100,6 +100,9 @@ class RetryClient extends BaseClient {
 
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
+    assert(request.cancellationToken?.autoDispose == false,
+        'Auto-dispose Tokens are not allowed for retrys');
+
     final splitter = StreamSplitter(request.finalize());
 
     var i = 0;

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 
 import 'base_request.dart';
 import 'byte_stream.dart';
+import 'cancelation_token.dart';
 import 'client.dart';
 import 'exception.dart';
 import 'request.dart';
@@ -19,43 +20,66 @@ import 'streamed_response.dart';
 /// maybe [close], and then they get various convenience methods for free.
 abstract class BaseClient implements Client {
   @override
-  Future<Response> head(Uri url, {Map<String, String>? headers}) =>
-      _sendUnstreamed('HEAD', url, headers);
+  Future<Response> head(Uri url,
+          {Map<String, String>? headers,
+          CancellationToken? cancellationToken}) =>
+      _sendUnstreamed('HEAD', url, headers, cancellationToken);
 
   @override
-  Future<Response> get(Uri url, {Map<String, String>? headers}) =>
-      _sendUnstreamed('GET', url, headers);
+  Future<Response> get(Uri url,
+          {Map<String, String>? headers,
+          CancellationToken? cancellationToken}) =>
+      _sendUnstreamed('GET', url, headers, cancellationToken);
 
   @override
   Future<Response> post(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('POST', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          CancellationToken? cancellationToken}) =>
+      _sendUnstreamed('POST', url, headers, cancellationToken, body, encoding);
 
   @override
   Future<Response> put(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('PUT', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          CancellationToken? cancellationToken}) =>
+      _sendUnstreamed('PUT', url, headers, cancellationToken, body, encoding);
 
   @override
   Future<Response> patch(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('PATCH', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          CancellationToken? cancellationToken}) =>
+      _sendUnstreamed('PATCH', url, headers, cancellationToken, body, encoding);
 
   @override
   Future<Response> delete(Uri url,
-          {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
-      _sendUnstreamed('DELETE', url, headers, body, encoding);
+          {Map<String, String>? headers,
+          Object? body,
+          Encoding? encoding,
+          CancellationToken? cancellationToken}) =>
+      _sendUnstreamed(
+          'DELETE', url, headers, cancellationToken, body, encoding);
 
   @override
-  Future<String> read(Uri url, {Map<String, String>? headers}) async {
-    final response = await get(url, headers: headers);
+  Future<String> read(Uri url,
+      {Map<String, String>? headers,
+      CancellationToken? cancellationToken}) async {
+    final response =
+        await get(url, headers: headers, cancellationToken: cancellationToken);
     _checkResponseSuccess(url, response);
     return response.body;
   }
 
   @override
-  Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers}) async {
-    final response = await get(url, headers: headers);
+  Future<Uint8List> readBytes(Uri url,
+      {Map<String, String>? headers,
+      CancellationToken? cancellationToken}) async {
+    final response =
+        await get(url, headers: headers, cancellationToken: cancellationToken);
     _checkResponseSuccess(url, response);
     return response.bodyBytes;
   }
@@ -71,10 +95,10 @@ abstract class BaseClient implements Client {
   Future<StreamedResponse> send(BaseRequest request);
 
   /// Sends a non-streaming [Request] and returns a non-streaming [Response].
-  Future<Response> _sendUnstreamed(
-      String method, Uri url, Map<String, String>? headers,
+  Future<Response> _sendUnstreamed(String method, Uri url,
+      Map<String, String>? headers, CancellationToken? cancellationToken,
       [body, Encoding? encoding]) async {
-    var request = Request(method, url);
+    var request = Request(method, url, cancellationToken: cancellationToken);
 
     if (headers != null) request.headers.addAll(headers);
     if (encoding != null) request.encoding = encoding;

--- a/lib/src/base_request.dart
+++ b/lib/src/base_request.dart
@@ -10,6 +10,7 @@ import '../http.dart' show get;
 import 'base_client.dart';
 import 'base_response.dart';
 import 'byte_stream.dart';
+import 'cancelation_token.dart';
 import 'client.dart';
 import 'streamed_response.dart';
 import 'utils.dart';
@@ -29,6 +30,8 @@ abstract class BaseRequest {
 
   /// The URL to which the request will be sent.
   final Uri url;
+
+  final CancellationToken? cancellationToken;
 
   /// The size of the request body, in bytes.
   ///
@@ -96,7 +99,7 @@ abstract class BaseRequest {
     return method;
   }
 
-  BaseRequest(String method, this.url)
+  BaseRequest(String method, this.url, {this.cancellationToken})
       : method = _validateMethod(method),
         headers = LinkedHashMap(
             equals: (key1, key2) => key1.toLowerCase() == key2.toLowerCase(),

--- a/lib/src/cancelation_token.dart
+++ b/lib/src/cancelation_token.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'exception.dart';
+
+typedef _AbortFunc = void Function();
+
+class CancellationToken {
+  /// Will automatically dispose the token after a request has been completed.
+  ///
+  /// Set it to `true` when you use the token for a single request.
+  ///
+  /// For retries or multi-request, set this to `false` and
+  /// `completeToken()` has to be called manually.
+  final bool autoDispose;
+
+  bool _cancellationPending = false;
+
+  final _cancellationStreamController = StreamController<void>.broadcast();
+  final _requestSubscriptions = <dynamic, StreamSubscription<void>>{};
+
+  CancellationToken({required this.autoDispose});
+
+  /// If token is not disposed yet
+  bool get isDisposed => _cancellationStreamController.isClosed;
+
+  Future _cancel() {
+    _cancellationPending = true;
+
+    if (_cancellationStreamController.hasListener) {
+      _cancellationStreamController.add(null);
+      if (autoDispose) {
+        return disposeToken();
+      }
+    }
+
+    return Future.value();
+  }
+
+  /// Cancels all registered requests and eventually disposes the token
+  Future cancel() {
+    if (!isDisposed) {
+      return _cancel();
+    }
+
+    throw CancellationTokenException('Token already disposed', this);
+  }
+
+  _AbortFunc? _getAbortOfRequest(dynamic request) {
+    //We have to do this completely dynamically, because no imports for
+    //typechecking are possible
+    try {
+      // ignore: avoid_dynamic_calls
+      return request.abort as _AbortFunc;
+      // ignore: avoid_catching_errors
+    } on Error catch (_) {
+      return null;
+    }
+  }
+
+  /// Check if a request and it's type is supported by the token
+  bool isRequestSupported(dynamic request) =>
+      _getAbortOfRequest(request) != null;
+
+  /// Registers a request
+  ///
+  /// You only have to call this, when you are manually working with `Request`'s
+  /// yourself. Elsewise it is handled by `Client`.
+  Future registerRequest(dynamic request) {
+    if (!isDisposed) {
+      final abortFunc = _getAbortOfRequest(request);
+      if (abortFunc != null) {
+        _requestSubscriptions.putIfAbsent(
+            request,
+            () =>
+                _cancellationStreamController.stream.listen((_) => abortFunc));
+
+        if (_cancellationPending) {
+          abortFunc.call();
+          return completeRequest(request);
+        }
+
+        return Future.value();
+      }
+
+      throw UnsupportedError(
+          '$CancellationToken does not support ${request.runtimeType}'
+          ' as request');
+    }
+
+    throw CancellationTokenException('Token already disposed', this);
+  }
+
+  /// Marks a request as completed and eventually disposes the token
+  ///
+  /// You only have to call this, when you are manually working with `Request`'s
+  /// yourself. Elsewise it is handled by `Client`.
+  Future completeRequest(dynamic request) async {
+    if (!isDisposed) {
+      final subscription = _requestSubscriptions[request];
+      if (subscription != null) {
+        await subscription.cancel();
+        _requestSubscriptions.remove(request);
+
+        if (autoDispose && _requestSubscriptions.isEmpty) {
+          return disposeToken();
+        }
+
+        return Future.value();
+      }
+    }
+  }
+
+  /// Disposes token
+  Future disposeToken() async {
+    if (!isDisposed) {
+      _requestSubscriptions.clear();
+      return _cancellationStreamController.close();
+    }
+  }
+}

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 
 import 'base_client.dart';
 import 'base_request.dart';
+import 'cancelation_token.dart';
 import 'client_stub.dart'
     if (dart.library.html) 'browser_client.dart'
     if (dart.library.io) 'io_client.dart';
@@ -34,12 +35,14 @@ abstract class Client {
   /// Sends an HTTP HEAD request with the given headers to the given URL.
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> head(Uri url, {Map<String, String>? headers});
+  Future<Response> head(Uri url,
+      {Map<String, String>? headers, CancellationToken? cancellationToken});
 
   /// Sends an HTTP GET request with the given headers to the given URL.
   ///
   /// For more fine-grained control over the request, use [send] instead.
-  Future<Response> get(Uri url, {Map<String, String>? headers});
+  Future<Response> get(Uri url,
+      {Map<String, String>? headers, CancellationToken? cancellationToken});
 
   /// Sends an HTTP POST request with the given headers and body to the given
   /// URL.
@@ -60,7 +63,10 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> post(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      CancellationToken? cancellationToken,
+      Object? body,
+      Encoding? encoding});
 
   /// Sends an HTTP PUT request with the given headers and body to the given
   /// URL.
@@ -81,7 +87,10 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> put(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      CancellationToken? cancellationToken,
+      Object? body,
+      Encoding? encoding});
 
   /// Sends an HTTP PATCH request with the given headers and body to the given
   /// URL.
@@ -102,13 +111,19 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> patch(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      CancellationToken? cancellationToken,
+      Object? body,
+      Encoding? encoding});
 
   /// Sends an HTTP DELETE request with the given headers to the given URL.
   ///
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> delete(Uri url,
-      {Map<String, String>? headers, Object? body, Encoding? encoding});
+      {Map<String, String>? headers,
+      CancellationToken? cancellationToken,
+      Object? body,
+      Encoding? encoding});
 
   /// Sends an HTTP GET request with the given headers to the given URL and
   /// returns a Future that completes to the body of the response as a String.
@@ -118,7 +133,8 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
-  Future<String> read(Uri url, {Map<String, String>? headers});
+  Future<String> read(Uri url,
+      {Map<String, String>? headers, CancellationToken? cancellationToken});
 
   /// Sends an HTTP GET request with the given headers to the given URL and
   /// returns a Future that completes to the body of the response as a list of
@@ -129,7 +145,8 @@ abstract class Client {
   ///
   /// For more fine-grained control over the request and response, use [send] or
   /// [get] instead.
-  Future<Uint8List> readBytes(Uri url, {Map<String, String>? headers});
+  Future<Uint8List> readBytes(Uri url,
+      {Map<String, String>? headers, CancellationToken? cancellationToken});
 
   /// Sends an HTTP request and asynchronously returns the response.
   Future<StreamedResponse> send(BaseRequest request);

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'cancelation_token.dart';
+
 /// An exception caused by an error in a pkg/http client.
 class ClientException implements Exception {
   final String message;
@@ -10,6 +12,19 @@ class ClientException implements Exception {
   final Uri? uri;
 
   ClientException(this.message, [this.uri]);
+
+  @override
+  String toString() => message;
+}
+
+/// An exception caused by an CancellationToken.
+class CancellationTokenException implements Exception {
+  final String message;
+
+  /// The related token
+  final CancellationToken? token;
+
+  CancellationTokenException(this.message, [this.token]);
 
   @override
   String toString() => message;

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -29,6 +29,10 @@ class IOClient extends BaseClient {
           'HTTP request failed. Client is already closed.', request.url);
     }
 
+    if (request.cancellationToken?.isCancellationPending == true) {
+      throw ClientException('Request has been aborted', request.url);
+    }
+
     var stream = request.finalize();
     HttpClientRequest? ioRequest;
 
@@ -46,7 +50,8 @@ class IOClient extends BaseClient {
     }
 
     try {
-      await request.cancellationToken?.registerRequest(ioRequest);
+      await request.cancellationToken
+          ?.registerRequest(ioRequest.abort, baseRequest: request);
       var response = await stream.pipe(ioRequest) as HttpClientResponse;
 
       var headers = <String, String>{};

--- a/lib/src/multipart_request.dart
+++ b/lib/src/multipart_request.dart
@@ -8,6 +8,7 @@ import 'dart:math';
 import 'base_request.dart';
 import 'boundary_characters.dart';
 import 'byte_stream.dart';
+import 'cancelation_token.dart';
 import 'multipart_file.dart';
 import 'utils.dart';
 
@@ -45,7 +46,9 @@ class MultipartRequest extends BaseRequest {
   /// The list of files to upload for this request.
   final files = <MultipartFile>[];
 
-  MultipartRequest(String method, Uri url) : super(method, url);
+  MultipartRequest(String method, Uri url,
+      {CancellationToken? cancellationToken})
+      : super(method, url, cancellationToken: cancellationToken);
 
   /// The total length of the request body, in bytes.
   ///

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -9,6 +9,7 @@ import 'package:http_parser/http_parser.dart';
 
 import 'base_request.dart';
 import 'byte_stream.dart';
+import 'cancelation_token.dart';
 import 'utils.dart';
 
 /// An HTTP request where the entire request body is known in advance.
@@ -137,10 +138,10 @@ class Request extends BaseRequest {
     body = mapToQuery(fields, encoding: encoding);
   }
 
-  Request(String method, Uri url)
+  Request(String method, Uri url, {CancellationToken? cancellationToken})
       : _defaultEncoding = utf8,
         _bodyBytes = Uint8List(0),
-        super(method, url);
+        super(method, url, cancellationToken: cancellationToken);
 
   /// Freezes all mutable fields and returns a single-subscription [ByteStream]
   /// containing the request body.

--- a/lib/src/streamed_request.dart
+++ b/lib/src/streamed_request.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'base_client.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';
+import 'cancelation_token.dart';
 
 /// An HTTP request where the request body is sent asynchronously after the
 /// connection has been established and the headers have been sent.
@@ -29,9 +30,10 @@ class StreamedRequest extends BaseRequest {
   final StreamController<List<int>> _controller;
 
   /// Creates a new streaming request.
-  StreamedRequest(String method, Uri url)
+  StreamedRequest(String method, Uri url,
+      {CancellationToken? cancellationToken})
       : _controller = StreamController<List<int>>(sync: true),
-        super(method, url);
+        super(method, url, cancellationToken: cancellationToken);
 
   /// Freezes all mutable fields and returns a single-subscription [ByteStream]
   /// that emits the data being written to [sink].

--- a/test/http_retry_test.dart
+++ b/test/http_retry_test.dart
@@ -5,6 +5,7 @@
 import 'package:fake_async/fake_async.dart';
 import 'package:http/http.dart';
 import 'package:http/retry.dart';
+import 'package:http/src/cancelation_token.dart';
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
 
@@ -13,7 +14,8 @@ void main() {
     test('a request has a non-503 error code', () async {
       final client = RetryClient(
           MockClient(expectAsync1((_) async => Response('', 502), count: 1)));
-      final response = await client.get(Uri.http('example.org', ''));
+      final response = await client.get(Uri.http('example.org', ''),
+          cancellationToken: CancellationToken(autoDispose: false));
       expect(response.statusCode, equals(502));
     });
 
@@ -21,7 +23,8 @@ void main() {
       final client = RetryClient(
           MockClient(expectAsync1((_) async => Response('', 503), count: 1)),
           when: (_) => false);
-      final response = await client.get(Uri.http('example.org', ''));
+      final response = await client.get(Uri.http('example.org', ''),
+          cancellationToken: CancellationToken(autoDispose: false));
       expect(response.statusCode, equals(503));
     });
 
@@ -29,7 +32,8 @@ void main() {
       final client = RetryClient(
           MockClient(expectAsync1((_) async => Response('', 503), count: 1)),
           retries: 0);
-      final response = await client.get(Uri.http('example.org', ''));
+      final response = await client.get(Uri.http('example.org', ''),
+          cancellationToken: CancellationToken(autoDispose: false));
       expect(response.statusCode, equals(503));
     });
   });
@@ -43,7 +47,8 @@ void main() {
         }, count: 2)),
         delay: (_) => Duration.zero);
 
-    final response = await client.get(Uri.http('example.org', ''));
+    final response = await client.get(Uri.http('example.org', ''),
+        cancellationToken: CancellationToken(autoDispose: false));
     expect(response.statusCode, equals(200));
   });
 
@@ -58,7 +63,8 @@ void main() {
         when: (response) => response.headers['retry'] == 'true',
         delay: (_) => Duration.zero);
 
-    final response = await client.get(Uri.http('example.org', ''));
+    final response = await client.get(Uri.http('example.org', ''),
+        cancellationToken: CancellationToken(autoDispose: false));
     expect(response.headers, containsPair('retry', 'false'));
     expect(response.statusCode, equals(503));
   });
@@ -75,7 +81,8 @@ void main() {
             error is StateError && error.message == 'oh no',
         delay: (_) => Duration.zero);
 
-    final response = await client.get(Uri.http('example.org', ''));
+    final response = await client.get(Uri.http('example.org', ''),
+        cancellationToken: CancellationToken(autoDispose: false));
     expect(response.statusCode, equals(200));
   });
 
@@ -85,7 +92,9 @@ void main() {
         whenError: (error, _) => error == 'oh yeah',
         delay: (_) => Duration.zero);
 
-    expect(client.get(Uri.http('example.org', '')),
+    expect(
+        client.get(Uri.http('example.org', ''),
+            cancellationToken: CancellationToken(autoDispose: false)),
         throwsA(isStateError.having((e) => e.message, 'message', 'oh no')));
   });
 
@@ -93,7 +102,8 @@ void main() {
     final client = RetryClient(
         MockClient(expectAsync1((_) async => Response('', 503), count: 4)),
         delay: (_) => Duration.zero);
-    final response = await client.get(Uri.http('example.org', ''));
+    final response = await client.get(Uri.http('example.org', ''),
+        cancellationToken: CancellationToken(autoDispose: false));
     expect(response.statusCode, equals(503));
   });
 
@@ -102,7 +112,8 @@ void main() {
         MockClient(expectAsync1((_) async => Response('', 503), count: 13)),
         retries: 12,
         delay: (_) => Duration.zero);
-    final response = await client.get(Uri.http('example.org', ''));
+    final response = await client.get(Uri.http('example.org', ''),
+        cancellationToken: CancellationToken(autoDispose: false));
     expect(response.statusCode, equals(503));
   });
 
@@ -124,7 +135,10 @@ void main() {
         return Response('', 503);
       }, count: 4)));
 
-      expect(client.get(Uri.http('example.org', '')), completes);
+      expect(
+          client.get(Uri.http('example.org', ''),
+              cancellationToken: CancellationToken(autoDispose: false)),
+          completes);
       fake.elapse(const Duration(minutes: 10));
     });
   });
@@ -149,7 +163,10 @@ void main() {
           }, count: 4)),
           delay: (requestCount) => Duration(seconds: requestCount));
 
-      expect(client.get(Uri.http('example.org', '')), completes);
+      expect(
+          client.get(Uri.http('example.org', ''),
+              cancellationToken: CancellationToken(autoDispose: false)),
+          completes);
       fake.elapse(const Duration(minutes: 10));
     });
   });
@@ -178,7 +195,10 @@ void main() {
             Duration(seconds: 12)
           ]);
 
-      expect(client.get(Uri.http('example.org', '')), completes);
+      expect(
+          client.get(Uri.http('example.org', ''),
+              cancellationToken: CancellationToken(autoDispose: false)),
+          completes);
       fake.elapse(const Duration(minutes: 10));
     });
   });
@@ -195,7 +215,8 @@ void main() {
           expect(retryCount, equals(count));
           count++;
         }, count: 2));
-    final response = await client.get(Uri.http('example.org', ''));
+    final response = await client.get(Uri.http('example.org', ''),
+        cancellationToken: CancellationToken(autoDispose: false));
     expect(response.statusCode, equals(503));
   });
 
@@ -214,7 +235,8 @@ void main() {
         }, count: 2)),
         [Duration.zero]);
 
-    final request = Request('POST', Uri.parse('http://example.org'))
+    final request = Request('POST', Uri.parse('http://example.org'),
+        cancellationToken: CancellationToken(autoDispose: false))
       ..body = 'hello'
       ..followRedirects = false
       ..headers['foo'] = 'bar'


### PR DESCRIPTION
This is an effort trying to tackle the problems discussed in #567, #424, and #204.

This solution introduces a `CancellationToken`, which is passed into the http-methods of `Client` e.g.:
```dart
http.get(url,
      cancellationToken: http.CancellationToken(autoDispose: false));
```
This design is avoiding breaking changes.

Despite most  cancellation-token-based solutions (working with a simple `Completer`), this approach is also trying to really `abort()`a request if necessary.

It is possible to add multiple requests to a `CancellationToken`, to cancel them at once when triggered (disposal of the token has to get done manually in that case).

A request can (if requested) get aborted at multiple points:
1. Before the request is getting prepared
2. When the request is getting registered at the `CancellationToken`
3. When the request is running, through a `Stream`-based invoke of `abort()` 

Status:
Cancellation is supported and implemented for both `IOClient` and `BrowserClient`.
Existing tests have been fixed, but no new tests written yet.
It will need some further reviews.

Problems:
The `abort()` on `HttpRequest` (for web) doesn't seem to have any effect during my tests (request time < 800ms) - although it's called during the according `readyState` (https://api.flutter.dev/flutter/dart-html/HttpRequest/abort.html)
