### PR TITLE
Fix response request in MockClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.13.5-dev
 
 * Allow async callbacks in RetryClient.
+* Use callback returned Response.request instead of the passed request to give
+  more control. This may be breaking for callbacks which return incomplete
+  Responses and relied on the default.
 
 ## 0.13.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 0.13.5-dev
 
 * Allow async callbacks in RetryClient.
-* Use callback returned Response.request instead of the passed request to give
-  more control. This may be breaking for callbacks which return incomplete
-  Responses and relied on the default.
+* In `MockHttpClient` use the callback returned `Response.request` instead of
+  the argument value to give more control to the callback. This may be breaking
+  for callbacks which return incomplete Responses and relied on the default.
 
 ## 0.13.4
 

--- a/lib/src/mock_client.dart
+++ b/lib/src/mock_client.dart
@@ -43,7 +43,7 @@ class MockClient extends BaseClient {
           return StreamedResponse(
               ByteStream.fromBytes(response.bodyBytes), response.statusCode,
               contentLength: response.contentLength,
-              request: baseRequest,
+              request: response.request,
               headers: response.headers,
               isRedirect: response.isRedirect,
               persistentConnection: response.persistentConnection,
@@ -57,7 +57,7 @@ class MockClient extends BaseClient {
           final response = await fn(request, bodyStream);
           return StreamedResponse(response.stream, response.statusCode,
               contentLength: response.contentLength,
-              request: request,
+              request: response.request,
               headers: response.headers,
               isRedirect: response.isRedirect,
               persistentConnection: response.persistentConnection,


### PR DESCRIPTION
This fix helps solve the following cases:

```dart
MockClient((request) async {
  request.headers.addAll({"Content-Type": "application/json"});
  return Response("{}", 200, request: request);
});
```

By having `baseRequest` instead of `response.request` in `mock_client.dart` we would never be able to capture the new request headers.

