### PR TITLE
Async support for when, whenError and onRetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.5-dev
+
+* Allow async callbacks in RetryClient.
+
 ## 0.13.4
 
 * Throw a more useful error when a client is used after it has been closed.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 0.13.4
+version: 0.13.5-dev
 homepage: https://github.com/dart-lang/http
 description: A composable, multi-platform, Future-based API for HTTP requests.
 


### PR DESCRIPTION
Addresses issue #645 .

In a general way, it add support for assigning async callbacks to when, whenError and onRetry