### PR TITLE
Add support for brotli compressed response bodies

### DIFF
--- a/lib/src/response.dart
+++ b/lib/src/response.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
+import 'package:brotli/brotli.dart';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -25,7 +25,17 @@ class Response extends BaseResponse {
   /// [RFC 2616][].
   ///
   /// [RFC 2616]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html
-  String get body => _encodingForHeaders(headers).decode(bodyBytes);
+
+  String decodeBody() {
+    List<int> newBodyBytes = bodyBytes;
+    if (headers['content-encoding'] == 'br' ||
+        headers['Content-Encoding'] == 'br') {
+      newBodyBytes = brotli.decode(bodyBytes);
+    }
+    return _encodingForHeaders(headers).decode(newBodyBytes);
+  }
+
+  String get body => decodeBody();
 
   /// Creates a new HTTP response with a string body.
   Response(String body, int statusCode,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   http_parser: ^4.0.0
   meta: ^1.3.0
   path: ^1.8.0
+  brotli: ^0.5.0
 
 dev_dependencies:
   fake_async: ^1.2.0


### PR DESCRIPTION
Most websites now prefer to send response bodies compressed with [Brotli](https://en.wikipedia.org/wiki/Brotli) because it usually results in better compression results.

The current dart client doesn't support this and so this PR adds Brotli decompression support.