### PR TITLE
Separate the `post` description for "String"

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -48,7 +48,7 @@ abstract class Client {
   /// or a [Map<String, String>].
   ///
   /// If [body] is a String, it's encoded using [encoding] and used as the body
-  /// of the request. The content-type of the request will default to 
+  /// of the request. The content-type of the request will default to
   /// "text/plain".
   ///
   /// If [body] is a List, it's used as a list of bytes for the body of the

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -45,9 +45,11 @@ abstract class Client {
   /// URL.
   ///
   /// [body] sets the body of the request. It can be a [String], a [List<int>]
-  /// or a [Map<String, String>]. If it's a String, it's encoded using
-  /// [encoding] and used as the body of the request. The content-type of the
-  /// request will default to "text/plain".
+  /// or a [Map<String, String>].
+  ///
+  /// If [body] is a String, it's encoded using [encoding] and used as the body
+  /// of the request. The content-type of the request will default to 
+  /// "text/plain".
   ///
   /// If [body] is a List, it's used as a list of bytes for the body of the
   /// request.


### PR DESCRIPTION
To make it more clear that the content-type header docs only apply to it.