### PR TITLE
Use the Uri.http constructor in docs and tests

### DIFF
--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -15,12 +15,12 @@ you to make individual HTTP requests with minimal hassle:
 ```dart
 import 'package:http/http.dart' as http;
 
-var url = Uri.parse('https://example.com/whatsit/create');
+var url = Uri.https('example.com', 'whatsit/create');
 var response = await http.post(url, body: {'name': 'doodle', 'color': 'blue'});
 print('Response status: ${response.statusCode}');
 print('Response body: ${response.body}');
 
-print(await http.read(Uri.parse('https://example.com/foobar.txt')));
+print(await http.read(Uri.https('example.com', 'foobar.txt')));
 ```
 
 If you're making multiple requests to the same server, you can keep open a
@@ -87,7 +87,7 @@ import 'package:http/retry.dart';
 Future<void> main() async {
   final client = RetryClient(http.Client());
   try {
-    print(await client.read(Uri.parse('http://example.org')));
+    print(await client.read(Uri.http('example.org', '')));
   } finally {
     client.close();
   }

--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -177,7 +177,7 @@ Client? get zoneClient {
 ///
 /// void myFunction() {
 ///   // Uses the `Client` configured in `main`.
-///   final response = await get(Uri.parse("https://www.example.com/"));
+///   final response = await get(Uri.https('www.example.com', ''));
 ///   final client = Client();
 /// }
 /// ```

--- a/pkgs/http/lib/src/multipart_request.dart
+++ b/pkgs/http/lib/src/multipart_request.dart
@@ -21,7 +21,7 @@ final _newlineRegExp = RegExp(r'\r\n|\r|\n');
 /// This request automatically sets the Content-Type header to
 /// `multipart/form-data`. This value will override any value set by the user.
 ///
-///     var uri = Uri.parse('https://example.com/create');
+///     var uri = Uri.https('example.com', 'create');
 ///     var request = http.MultipartRequest('POST', uri)
 ///       ..fields['user'] = 'nweiz@google.com'
 ///       ..files.add(await http.MultipartFile.fromPath(

--- a/pkgs/http/test/html/client_test.dart
+++ b/pkgs/http/test/html/client_test.dart
@@ -28,7 +28,7 @@ void main() {
 
   test('#send with an invalid URL', () {
     var client = BrowserClient();
-    var url = Uri.parse('http://http.invalid');
+    var url = Uri.http('http.invalid', '');
     var request = http.StreamedRequest('POST', url);
 
     expect(

--- a/pkgs/http/test/http_retry_test.dart
+++ b/pkgs/http/test/http_retry_test.dart
@@ -208,13 +208,13 @@ void main() {
           expect(request.maxRedirects, equals(12));
           expect(request.method, equals('POST'));
           expect(request.persistentConnection, isFalse);
-          expect(request.url, equals(Uri.parse('http://example.org')));
+          expect(request.url, equals(Uri.http('example.org', '')));
           expect(request.body, equals('hello'));
           return Response('', 503);
         }, count: 2)),
         [Duration.zero]);
 
-    final request = Request('POST', Uri.parse('http://example.org'))
+    final request = Request('POST', Uri.http('example.org', ''))
       ..body = 'hello'
       ..followRedirects = false
       ..headers['foo'] = 'bar'

--- a/pkgs/http/test/io/client_test.dart
+++ b/pkgs/http/test/io/client_test.dart
@@ -111,7 +111,7 @@ void main() {
 
   test('#send with an invalid URL', () {
     var client = http.Client();
-    var url = Uri.parse('http://http.invalid');
+    var url = Uri.http('http.invalid', '');
     var request = http.StreamedRequest('POST', url);
     request.headers[HttpHeaders.contentTypeHeader] =
         'application/json; charset=utf-8';

--- a/pkgs/http/test/utils.dart
+++ b/pkgs/http/test/utils.dart
@@ -9,7 +9,7 @@ import 'package:http_parser/http_parser.dart';
 import 'package:test/test.dart';
 
 /// A dummy URL for constructing requests that won't be sent.
-Uri get dummyUrl => Uri.parse('http://dart.dev/');
+Uri get dummyUrl => Uri.http('dart.dev', '');
 
 /// Removes eight spaces of leading indentation from a multiline string.
 ///


### PR DESCRIPTION
Use `Uri.parse` when the string is completely opaque to the calling
code. When the calling code is hardcoding the protocol, use the protocol
specific constructor.