### PR TITLE
add a LICENSE file; tweaks to the readmes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2014, the Dart project authors. 
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-A composable, Future-based library for making HTTP requests.
-
 [![Build Status](https://github.com/dart-lang/http/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/http/actions?query=workflow%3A"Dart+CI"+branch%3Amaster)
+
+A composable, Future-based library for making HTTP requests.
 
 `package:http` contains a set of high-level functions and classes that make it
 easy to consume HTTP resources. It's multi-platform, and supports mobile, desktop,
@@ -10,5 +10,5 @@ and the browser.
 
 | Package | Description | Version |
 |---|---|---|
-| [http](pkgs/http/) | A composable, Future-based library for making HTTP requests. | [![pub package](https://img.shields.io/pub/v/http.svg)](https://pub.dev/packages/http) |
-| [http_client_conformance_tests](pkgs/http_client_conformance_tests/) | Tests for `package:http` `Client` implementations. | [![pub package](https://img.shields.io/pub/v/http_client_conformance_tests.svg)](https://pub.dev/packages/http_client_conformance_tests) |
+| [http](pkgs/http/) | A composable, multi-platform, Future-based API for HTTP requests. | [![pub package](https://img.shields.io/pub/v/http.svg)](https://pub.dev/packages/http) |
+| [http_client_conformance_tests](pkgs/http_client_conformance_tests/) | A library that tests whether implementations of package:http's `Client` class behave as expected. | |

--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -1,7 +1,7 @@
-A composable, Future-based library for making HTTP requests.
-
 [![pub package](https://img.shields.io/pub/v/http.svg)](https://pub.dev/packages/http)
-[![Build Status](https://github.com/dart-lang/http/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/http/actions?query=workflow%3A"Dart+CI"+branch%3Amaster)
+[![package publisher](https://img.shields.io/pub/publisher/http.svg)](https://pub.dev/packages/http/publisher)
+
+A composable, Future-based library for making HTTP requests.
 
 This package contains a set of high-level functions and classes that make it
 easy to consume HTTP resources. It's multi-platform, and supports mobile, desktop,

--- a/pkgs/http_client_conformance_tests/README.md
+++ b/pkgs/http_client_conformance_tests/README.md
@@ -1,16 +1,18 @@
+[![pub package](https://img.shields.io/pub/v/http_client_conformance_tests.svg)](https://pub.dev/packages/http_client_conformance_tests)
+
 A library that tests whether implementations of `package:http`
-[`Client`'](https://pub.dev/documentation/http/latest/http/Client-class.html)
+[`Client`](https://pub.dev/documentation/http/latest/http/Client-class.html)
 behave as expected.
 
 This package is intended to be used in the tests of packages that implement
 `package:http`
-[`Client`'](https://pub.dev/documentation/http/latest/http/Client-class.html).
+[`Client`](https://pub.dev/documentation/http/latest/http/Client-class.html).
 
 ## Usage
 
 `package:http_client_conformance_tests` is meant to be used in the tests suite
 of a `package:http`
-[`Client`'](https://pub.dev/documentation/http/latest/http/Client-class.html)
+[`Client`](https://pub.dev/documentation/http/latest/http/Client-class.html)
 like:
 
 ```dart

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: http_client_conformance_tests
 description: >
-  A library that tests whether implementations of package:http Client behave
-  as expected.
+  A library that tests whether implementations of package:http's `Client` class
+  behave as expected.
 version: 0.0.1-dev
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http_client_conformance_tests
 


### PR DESCRIPTION
Misc changes:
- add a top-level LICENSE file (copied from pkg/http)
- various an misc tweaks to the READMEs (mostly around the markdown badges)

And when https://github.com/dart-lang/.github/pull/26 lands, we'll get associated 'contributing' verbiage for this repo.
