### PR TITLE
Add OPTIONS Method to Client Interface and Client Implementation

### DIFF
--- a/pkgs/http/lib/src/base_client.dart
+++ b/pkgs/http/lib/src/base_client.dart
@@ -27,6 +27,11 @@ abstract class BaseClient implements Client {
       _sendUnstreamed('GET', url, headers);
 
   @override
+  Future<Response> options(Uri url,
+      {Map<String, String>? headers}) =>
+      _sendUnstreamed('OPTIONS', url, headers);
+
+  @override
   Future<Response> post(Uri url,
           {Map<String, String>? headers, Object? body, Encoding? encoding}) =>
       _sendUnstreamed('POST', url, headers, body, encoding);

--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -46,6 +46,11 @@ abstract class Client {
   /// For more fine-grained control over the request, use [send] instead.
   Future<Response> get(Uri url, {Map<String, String>? headers});
 
+  /// Sends an HTTP OPTIONS request with the given headers to the given URL.
+  ///
+  /// For more fine-grained control over the request, use [send] instead.
+  Future<Response> options(Uri url, {Map<String, String>? headers});
+
   /// Sends an HTTP POST request with the given headers and body to the given
   /// URL.
   ///


### PR DESCRIPTION
Adds the `OPTIONS` method call to the `Client` interface so that the call can be invoked with the option to pass headers as opposed to trying to do it via raw `Request` which doesn't allow to set headers upon instantiation.