### PR TITLE
http_client_conformance_tests: no plan to publish

### DIFF
--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -1,8 +1,8 @@
 name: http_client_conformance_tests
-description: >
+description: >-
   A library that tests whether implementations of package:http's `Client` class
   behave as expected.
-version: 0.0.1-dev
+publish_to: none
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http_client_conformance_tests
 
 environment:


### PR DESCRIPTION
We can update this as needed.