### PR TITLE
Changed preserveHeaderCase from false to true for request headers.

### DIFF
--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -60,7 +60,7 @@ class IOClient extends BaseClient {
         ..contentLength = (request.contentLength ?? -1)
         ..persistentConnection = request.persistentConnection;
       request.headers.forEach((name, value) {
-        ioRequest.headers.set(name, value);
+        ioRequest.headers.set(name, value, preserveHeaderCase: true);
       });
 
       var response = await stream.pipe(ioRequest) as HttpClientResponse;


### PR DESCRIPTION
I have changed `preserveHeaderCase` for headers from `false` to `true`. The custom headers defined in the back end server were not accepting the case-sensitive header (`X-Auth-Signature`).
The result was that I couldn't make API requests and was getting 401 unauthorized responses all the time.

Once after setting `preserveHeaderCase` to true API has started working. Consider this change or is that it is possible to change `preserveHeaderCase` from `post/get/put/delete` methods, where actual API requests are made.

This is a problem that most others are experiencing as well - #[Reference Link](https://stackoverflow.com/questions/73133740/401-unauthorized-error-in-flutter-but-works-fine-in-postman)

@brianquinlan, @kevmoo, @mit-mit, @natebosch, @devoncarew, @osa1, @Hamaad-Siddiqui, @aam, @guyluz11 

Thank You