### PR TITLE
Drop avoid_redundant_argument_values

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,7 +13,6 @@ linter:
   - avoid_classes_with_only_static_members
   - avoid_dynamic_calls
   - avoid_private_typedef_functions
-  - avoid_redundant_argument_values
   - avoid_returning_this
   - avoid_unused_constructor_parameters
   - cascade_invocations


### PR DESCRIPTION
This lint is firing for `Uri.http` constructor calls where the `path`
argument is now optional. The argument values need to be retained until
the min SDK is updated. Drop the lint for now.
