### PR TITLE
✨ Add Cronet embedded tool

### DIFF
--- a/pkgs/cronet_http/README_EMBEDDED.md
+++ b/pkgs/cronet_http/README_EMBEDDED.md
@@ -1,0 +1,23 @@
+An Android Flutter plugin that provides access to the
+[Cronet](https://developer.android.com/guide/topics/connectivity/cronet/reference/org/chromium/net/package-summary)
+HTTP client.
+
+Cronet embedded is available as a standalone implementation
+which will brought additional 8MB for apps approximately.
+
+## Status: Experimental
+
+**NOTE**: This package is currently experimental and published under the
+[labs.dart.dev](https://dart.dev/dart-team-packages) pub publisher in order to
+solicit feedback. 
+
+For packages in the labs.dart.dev publisher we generally plan to either graduate
+the package into a supported publisher (dart.dev, tools.dart.dev) after a period
+of feedback and iteration, or discontinue the package. These packages have a
+much higher expected rate of API and breaking changes.
+
+Your feedback is valuable and will help us evolve this package. 
+For general feedback and suggestions please comment in the
+[feedback issue](https://github.com/dart-lang/http/issues/764).
+For bugs, please file an issue in the 
+[bug tracker](https://github.com/dart-lang/http/issues).

--- a/pkgs/cronet_http/README_EMBEDDED.md
+++ b/pkgs/cronet_http/README_EMBEDDED.md
@@ -2,22 +2,11 @@ An Android Flutter plugin that provides access to the
 [Cronet](https://developer.android.com/guide/topics/connectivity/cronet/reference/org/chromium/net/package-summary)
 HTTP client.
 
-Cronet embedded is available as a standalone implementation
-which will brought additional 8MB for apps approximately.
+This package is identical to [`package:cronet_http`](https://pub.dev/packages/cronet_http)
+except that it embeds
+[Cronet](https://developer.android.com/guide/topics/connectivity/cronet/reference/org/chromium/net/package-summary)
+rather than using the version included with
+[Google Play Services](https://developers.google.com/android/guides/overview).
+This increases the uncompressed size of the application by approximately 8MB.
 
-## Status: Experimental
-
-**NOTE**: This package is currently experimental and published under the
-[labs.dart.dev](https://dart.dev/dart-team-packages) pub publisher in order to
-solicit feedback. 
-
-For packages in the labs.dart.dev publisher we generally plan to either graduate
-the package into a supported publisher (dart.dev, tools.dart.dev) after a period
-of feedback and iteration, or discontinue the package. These packages have a
-much higher expected rate of API and breaking changes.
-
-Your feedback is valuable and will help us evolve this package. 
-For general feedback and suggestions please comment in the
-[feedback issue](https://github.com/dart-lang/http/issues/764).
-For bugs, please file an issue in the 
-[bug tracker](https://github.com/dart-lang/http/issues).
+See more details about the cronet_http at: https://pub.dev/packages/cronet_http.

--- a/pkgs/cronet_http/README_EMBEDDED.md
+++ b/pkgs/cronet_http/README_EMBEDDED.md
@@ -9,4 +9,4 @@ rather than using the version included with
 [Google Play Services](https://developers.google.com/android/guides/overview).
 This increases the uncompressed size of the application by approximately 8MB.
 
-See more details about the cronet_http at: https://pub.dev/packages/cronet_http.
+See more details about cronet_http at: https://pub.dev/packages/cronet_http.

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
   lints: ^1.0.0
   pigeon: ^3.2.3
   xml: ^6.1.0
+  yaml_edit: ^2.0.3
 
 flutter:
   plugin:

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.0
   pigeon: ^3.2.3
+  xml: ^6.1.0
 
 flutter:
   plugin:

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -47,9 +47,11 @@ void _writeImplementationToTheFile(String latestVersion) {
     ':\\d+.\\d+.\\d+[\'"]',
     multiLine: true,
   );
+  final newImplementation = 'org.chromium.net:cronet-embedded:$latestVersion';
+  print('Patching $newImplementation');
   final newGradleContent = gradleContent.replaceAll(
     implementationRegExp,
-    '    implementation "org.chromium.net:cronet-embedded:$latestVersion"',
+    '    implementation $newImplementation',
   );
   fBuildGradle.writeAsStringSync(newGradleContent);
   // Update pubspec.yaml

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 void main() async {
   final latestVersion = await _getLatestVersion();
@@ -53,10 +54,14 @@ void _writeImplementationToTheFile(String latestVersion) {
   fBuildGradle.writeAsStringSync(newGradleContent);
   // Update pubspec.yaml
   final fPubspec = File('${dir.path}/pubspec.yaml');
-  fPubspec.writeAsStringSync(
-    fPubspec.readAsStringSync().replaceAll(
-          RegExp(r'^name: cronet_http$'),
-          'name: cronet_http_embedded',
-        ),
-  );
+  final yamlEditor = YamlEditor(fPubspec.readAsStringSync())
+    ..update(['name'], 'cronet_http_embedded')
+    ..update(
+      ['description'],
+      'An Android Flutter plugin that '
+      'provides access to the Cronet HTTP client. '
+      'Identical to package:cronet_http except that it embeds Cronet '
+      'rather than relying on Google Play Services.',
+    );
+  fPubspec.writeAsStringSync(yamlEditor.toString());
 }

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -23,7 +23,7 @@ Future<String> _getLatestVersion() async {
       .singleWhere((e) => e is XmlElement)
       .children
       .singleWhere((e) => e is XmlElement && e.name.local == 'cronet-embedded');
-  final stableVersionReg = RegExp(r'^(\d+).(\d+).(\d+)$');
+  final stableVersionReg = RegExp(r'^\d+.\d+.\d+$');
   final versions = embeddedNode.attributes
       .singleWhere((e) => e.name.local == 'versions')
       .value
@@ -41,9 +41,9 @@ void _writeImplementationToTheFile(String latestVersion) {
   final fBuildGradle = File('${dir.path}/android/build.gradle');
   final gradleContent = fBuildGradle.readAsStringSync();
   final implementationRegExp = RegExp(
-    '^(\\s*)implementation [\'"]'
+    '^\\s*implementation [\'"]'
     'com.google.android.gms:play-services-cronet'
-    ':(\\d+.\\d+.\\d+)[\'"]',
+    ':\\d+.\\d+.\\d+[\'"]',
     multiLine: true,
   );
   final newGradleContent = gradleContent.replaceAll(

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -11,6 +11,7 @@ import 'package:yaml_edit/yaml_edit.dart';
 void main() async {
   final latestVersion = await _getLatestVersion();
   _writeImplementationToTheFile(latestVersion);
+  _replaceREADME();
 }
 
 Future<String> _getLatestVersion() async {
@@ -66,4 +67,13 @@ void _writeImplementationToTheFile(String latestVersion) {
       'rather than relying on Google Play Services.',
     );
   fPubspec.writeAsStringSync(yamlEditor.toString());
+}
+
+void _replaceREADME() {
+  var dir = Directory.current;
+  if (dir.path.endsWith('tool')) {
+    dir = dir.parent;
+  }
+  File('${dir.path}/README.md').deleteSync();
+  File('${dir.path}/README_EMBEDDED.md').renameSync('${dir.path}/README.md');
 }

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart';
+
+void main() async {
+  final latestVersion = await _getLatestVersion();
+  _writeImplementationToTheFile(latestVersion);
+}
+
+Future<String> _getLatestVersion() async {
+  final url = Uri.https(
+    'dl.google.com',
+    'android/maven2/org/chromium/net/group-index.xml',
+  );
+  final response = await http.get(url);
+  final parsedXml = XmlDocument.parse(response.body);
+  final embeddedNode = parsedXml.children
+      .singleWhere((e) => e is XmlElement)
+      .children
+      .singleWhere((e) => e is XmlElement && e.name.local == 'cronet-embedded');
+  final stableVersionReg = RegExp(r'^(\d+).(\d+).(\d+)$');
+  final versions = embeddedNode.attributes
+      .singleWhere((e) => e.name.local == 'versions')
+      .value
+      .split(',')
+      .where((e) => stableVersionReg.stringMatch(e) == e);
+  return versions.last;
+}
+
+void _writeImplementationToTheFile(String latestVersion) {
+  var dir = Directory.current;
+  if (dir.path.endsWith('tool')) {
+    dir = dir.parent;
+  }
+  // Update android/build.gradle
+  final fBuildGradle = File('${dir.path}/android/build.gradle');
+  final gradleContent = fBuildGradle.readAsStringSync();
+  final implementationRegExp = RegExp(
+    '^(\\s*)implementation [\'"]'
+    'com.google.android.gms:play-services-cronet'
+    ':(\\d+.\\d+.\\d+)[\'"]',
+    multiLine: true,
+  );
+  final newGradleContent = gradleContent.replaceAll(
+    implementationRegExp,
+    '    implementation "org.chromium.net:cronet-embedded:$latestVersion"',
+  );
+  fBuildGradle.writeAsStringSync(newGradleContent);
+  // Update pubspec.yaml
+  final fPubspec = File('${dir.path}/pubspec.yaml');
+  fPubspec.writeAsStringSync(
+    fPubspec.readAsStringSync().replaceAll(
+          RegExp(r'^name: cronet_http$'),
+          'name: cronet_http_embedded',
+        ),
+  );
+}

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -1,7 +1,23 @@
 // Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-// ignore_for_file: lines_longer_than_80_chars
+
+/// The cronet_http directory is used to produce two packages:
+/// - `cronet_http`, which uses the Google Play Services version of Cronet.
+/// - `cronet_http_embedded`, which embeds Cronet.
+///
+/// The default configuration of this code is to use the
+/// Google Play Services version of Cronet.
+///
+/// The script transforms the configuration into one that embeds Cronet by:
+/// 1. Modifying the Gradle build file to reference the embedded Cronet.
+/// 2. Modifying the *name* and *description* in `pubspec.yaml`.
+/// 3. Replacing `README.md` with `README_EMBEDDED.md`.
+///
+/// After running this script, `flutter pub publish`
+/// can be run to update package:cronet_http_embedded.
+///
+/// NOTE: This script modifies the above files in place.
 
 import 'dart:io';
 
@@ -9,39 +25,25 @@ import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
-/// The cronet_http directory is used to produce two packages:
-/// - `cronet_http`, which uses the Google Play Services version of Cronet.
-/// - `cronet_http_embedded`, which embeds Cronet.
-///
-/// The default configuration of this code is to use the Google Play Services version of Cronet.
-///
-/// The script transforms the configuration into one that embeds Cronet by:
-/// 1. Modifying the Gradle build file to reference the embedded version of Cronet.
-/// 2. Modifying the *name* and *description* in `pubspec.yaml`.
-/// 3. Replaying `README.md` with `README_EMBEDDED.md`.
-///
-/// After running this script, `flutter pub publish` can be run to update package:cronet_http_embedded.
-///
-/// NOTE: This script modifies the above files in place.
-late final Directory _directory;
+late final Directory _packageDirectory;
 
-const String _gmsDependencyName = 'com.google.android.gms:play-services-cronet';
-const String _embeddedDependencyName = 'org.chromium.net:cronet-embedded';
-const String _packageName = 'cronet_http_embedded';
-const String _packageDescription = 'An Android Flutter plugin that '
+const _gmsDependencyName = 'com.google.android.gms:play-services-cronet';
+const _embeddedDependencyName = 'org.chromium.net:cronet-embedded';
+const _packageName = 'cronet_http_embedded';
+const _packageDescription = 'An Android Flutter plugin that '
     'provides access to the Cronet HTTP client. '
     'Identical to package:cronet_http except that it embeds Cronet '
     'rather than relying on Google Play Services.';
-final Uri _cronetVersionUri = Uri.https(
+final _cronetVersionUri = Uri.https(
   'dl.google.com',
   'android/maven2/org/chromium/net/group-index.xml',
 );
 
 void main() async {
   if (Directory.current.path.endsWith('tool')) {
-    _directory = Directory.current.parent;
+    _packageDirectory = Directory.current.parent;
   } else {
-    _directory = Directory.current;
+    _packageDirectory = Directory.current;
   }
 
   final latestVersion = await _getLatestCronetVersion();
@@ -68,7 +70,7 @@ Future<String> _getLatestCronetVersion() async {
 
 /// Update android/build.gradle
 void updateCronetDependency(String latestVersion) {
-  final fBuildGradle = File('${_directory.path}/android/build.gradle');
+  final fBuildGradle = File('${_packageDirectory.path}/android/build.gradle');
   final gradleContent = fBuildGradle.readAsStringSync();
   final implementationRegExp = RegExp(
     '^\\s*implementation [\'"]'
@@ -87,7 +89,7 @@ void updateCronetDependency(String latestVersion) {
 
 /// Update pubspec.yaml
 void updatePubSpec() {
-  final fPubspec = File('${_directory.path}/pubspec.yaml');
+  final fPubspec = File('${_packageDirectory.path}/pubspec.yaml');
   final yamlEditor = YamlEditor(fPubspec.readAsStringSync())
     ..update(['name'], _packageName)
     ..update(['description'], _packageDescription);
@@ -96,7 +98,7 @@ void updatePubSpec() {
 
 /// Move README_EMBEDDED.md to replace README.md
 void updateReadme() {
-  File('${_directory.path}/README.md').deleteSync();
-  File('${_directory.path}/README_EMBEDDED.md')
-      .renameSync('${_directory.path}/README.md');
+  File('${_packageDirectory.path}/README.md').deleteSync();
+  File('${_packageDirectory.path}/README_EMBEDDED.md')
+      .renameSync('${_packageDirectory.path}/README.md');
 }

--- a/pkgs/cronet_http/tool/run_pigeon.sh
+++ b/pkgs/cronet_http/tool/run_pigeon.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Generate the platform messages used by cronet_http.
+cd ../
 
 flutter pub run pigeon \
   --input pigeons/messages.dart \


### PR DESCRIPTION
Resolves #807.

Creates a new tool for publishing the non-GMS-based Cronet package. The tool is implemented with these concerns:
* Not creating symlinks because the structure can be changed easily.
* Not to restrict running on a single platform, so it's been written in Dart.
* Only modify files, but do not publish in this tool, leave the process to the operator, since the latest stable version can have breaking changes and require further CI tests (more jobs in `.github/workflows`).
* As easy as possible to maintain the tool.