### PR TITLE
Remove dependency on package:path

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.13.6-dev
 
 * `BrowserClient` throws an exception if `send` is called after `close`.
+* No longer depends on package:path.
 
 ## 0.13.5
 

--- a/pkgs/http/lib/src/multipart_file_io.dart
+++ b/pkgs/http/lib/src/multipart_file_io.dart
@@ -11,7 +11,7 @@ import 'multipart_file.dart';
 
 Future<MultipartFile> multipartFileFromPath(String field, String filePath,
     {String? filename, MediaType? contentType}) async {
-  late var segments = File(filePath).uri.pathSegments;
+  late var segments = Uri.file(filePath).pathSegments;
   filename ??= segments.isEmpty ? '' : segments.last;
   var file = File(filePath);
   var length = await file.length();

--- a/pkgs/http/lib/src/multipart_file_io.dart
+++ b/pkgs/http/lib/src/multipart_file_io.dart
@@ -5,14 +5,14 @@
 import 'dart:io';
 
 import 'package:http_parser/http_parser.dart';
-import 'package:path/path.dart' as p;
 
 import 'byte_stream.dart';
 import 'multipart_file.dart';
 
 Future<MultipartFile> multipartFileFromPath(String field, String filePath,
     {String? filename, MediaType? contentType}) async {
-  filename ??= p.basename(filePath);
+  late var segments = File(filePath).uri.pathSegments;
+  filename ??= segments.isEmpty ? '' : segments.last;
   var file = File(filePath);
   var length = await file.length();
   var stream = ByteStream(file.openRead());

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   async: ^2.5.0
   http_parser: ^4.0.0
   meta: ^1.3.0
-  path: ^1.8.0
 
 dev_dependencies:
   fake_async: ^1.2.0

--- a/pkgs/http/test/io/multipart_test.dart
+++ b/pkgs/http/test/io/multipart_test.dart
@@ -20,9 +20,9 @@ void main() {
   tearDown(() => tempDir.deleteSync(recursive: true));
 
   test('with a file from disk', () async {
-    var filePath = tempDir.uri.resolve('test-file');
-    File.fromUri(filePath).writeAsStringSync('hello');
-    var file = await http.MultipartFile.fromPath('file', filePath.toFilePath());
+    var fileUri = tempDir.uri.resolve('test-file');
+    File.fromUri(fileUri).writeAsStringSync('hello');
+    var file = await http.MultipartFile.fromPath('file', fileUri.toFilePath());
     var request = http.MultipartRequest('POST', dummyUrl);
     request.files.add(file);
 

--- a/pkgs/http/test/io/multipart_test.dart
+++ b/pkgs/http/test/io/multipart_test.dart
@@ -7,7 +7,6 @@
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
-import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import '../utils.dart';
@@ -21,9 +20,9 @@ void main() {
   tearDown(() => tempDir.deleteSync(recursive: true));
 
   test('with a file from disk', () async {
-    var filePath = path.join(tempDir.path, 'test-file');
-    File(filePath).writeAsStringSync('hello');
-    var file = await http.MultipartFile.fromPath('file', filePath);
+    var filePath = tempDir.uri.resolve('test-file');
+    File.fromUri(filePath).writeAsStringSync('hello');
+    var file = await http.MultipartFile.fromPath('file', filePath.toFilePath());
     var request = http.MultipartRequest('POST', dummyUrl);
     request.files.add(file);
 


### PR DESCRIPTION
Outside `test/` it was only used for the `basename` functionality. We can use Uri.pathsegments.last for that.
