### PR TITLE
Add a flag to allow the default Client to be tree shaken away.

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -157,6 +157,41 @@ jobs:
         if: "always() && steps.pkgs_http_client_conformance_tests_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http_client_conformance_tests
   job_005:
+    name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http;commands:test_3"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: "2.14.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_http_pub_upgrade
+        name: pkgs/http; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http
+      - name: "pkgs/http; dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        run: "dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_006:
     name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -191,7 +226,42 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_006:
+  job_007:
+    name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http;commands:test_2"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: "2.14.0"
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_http_pub_upgrade
+        name: pkgs/http; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http
+      - name: "pkgs/http; dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        run: "dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_008:
     name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform vm`"
     runs-on: ubuntu-latest
     steps:
@@ -226,7 +296,42 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_007:
+  job_009:
+    name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http;commands:test_3"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_http_pub_upgrade
+        name: pkgs/http; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http
+      - name: "pkgs/http; dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        run: "dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_010:
     name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -261,7 +366,42 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_008:
+  job_011:
+    name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart`"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache Pub hosted dependencies
+        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
+        with:
+          path: "~/.pub-cache/hosted"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http;commands:test_2"
+          restore-keys: |
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
+            os:ubuntu-latest;pub-cache-hosted
+            os:ubuntu-latest
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+        with:
+          sdk: dev
+      - id: checkout
+        name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - id: pkgs_http_pub_upgrade
+        name: pkgs/http; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http
+      - name: "pkgs/http; dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        run: "dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http
+    needs:
+      - job_001
+      - job_002
+      - job_003
+      - job_004
+  job_012:
     name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform vm`"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -227,41 +227,6 @@ jobs:
       - job_003
       - job_004
   job_007:
-    name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http;commands:test_2"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http
-            os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: "2.14.0"
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_http_pub_upgrade
-        name: pkgs/http; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/http
-      - name: "pkgs/http; dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
-        run: "dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
-        if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/http
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_008:
     name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform vm`"
     runs-on: ubuntu-latest
     steps:
@@ -296,7 +261,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_009:
+  job_008:
     name: "unit_test; Dart dev; PKG: pkgs/http; `dart run --define=no_default_http_client=true test/no_default_http_client_test.dart`"
     runs-on: ubuntu-latest
     steps:
@@ -331,7 +296,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_010:
+  job_009:
     name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform chrome`"
     runs-on: ubuntu-latest
     steps:
@@ -366,42 +331,7 @@ jobs:
       - job_002
       - job_003
       - job_004
-  job_011:
-    name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart`"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache Pub hosted dependencies
-        uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
-        with:
-          path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http;commands:test_2"
-          restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev
-            os:ubuntu-latest;pub-cache-hosted
-            os:ubuntu-latest
-      - name: Setup Dart SDK
-        uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-        with:
-          sdk: dev
-      - id: checkout
-        name: Checkout repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - id: pkgs_http_pub_upgrade
-        name: pkgs/http; dart pub upgrade
-        run: dart pub upgrade
-        if: "always() && steps.checkout.conclusion == 'success'"
-        working-directory: pkgs/http
-      - name: "pkgs/http; dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
-        run: "dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart"
-        if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
-        working-directory: pkgs/http
-    needs:
-      - job_001
-      - job_002
-      - job_003
-      - job_004
-  job_012:
+  job_010:
     name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform vm`"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -157,14 +157,14 @@ jobs:
         if: "always() && steps.pkgs_http_client_conformance_tests_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http_client_conformance_tests
   job_005:
-    name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart`"
+    name: "unit_test; Dart 2.14.0; PKG: pkgs/http; `dart run --define=no_default_http_client=true test/no_default_http_client_test.dart`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http;commands:test_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http;commands:command"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0;packages:pkgs/http
             os:ubuntu-latest;pub-cache-hosted;sdk:2.14.0
@@ -182,8 +182,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/http
-      - name: "pkgs/http; dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
-        run: "dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
+      - name: "pkgs/http; dart run --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        run: "dart run --define=no_default_http_client=true test/no_default_http_client_test.dart"
         if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http
     needs:
@@ -297,14 +297,14 @@ jobs:
       - job_003
       - job_004
   job_009:
-    name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart`"
+    name: "unit_test; Dart dev; PKG: pkgs/http; `dart run --define=no_default_http_client=true test/no_default_http_client_test.dart`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@627f0f41f6904a5b1efbaed9f96d9eb58e92e920
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http;commands:test_3"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http;commands:command"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
@@ -322,8 +322,8 @@ jobs:
         run: dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
         working-directory: pkgs/http
-      - name: "pkgs/http; dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
-        run: "dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart"
+      - name: "pkgs/http; dart run --define=no_default_http_client=true test/no_default_http_client_test.dart"
+        run: "dart run --define=no_default_http_client=true test/no_default_http_client_test.dart"
         if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http
     needs:

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * `BrowserClient` throws an exception if `send` is called after `close`.
 * No longer depends on package:path.
+* If `no_default_http_client=true` is set in the environment then disk usage
+  is reduced in some circumstances.
 
 ## 0.13.5
 

--- a/pkgs/http/lib/src/browser_client.dart
+++ b/pkgs/http/lib/src/browser_client.dart
@@ -15,7 +15,13 @@ import 'streamed_response.dart';
 /// Create a [BrowserClient].
 ///
 /// Used from conditional imports, matches the definition in `client_stub.dart`.
-BaseClient createClient() => BrowserClient();
+BaseClient createClient() {
+  if (const bool.fromEnvironment('no_default_http_client')) {
+    throw StateError('no_default_http_client was defined but runWithClient '
+        'was not used to configure a Client implementation.');
+  }
+  return BrowserClient();
+}
 
 /// A `dart:html`-based HTTP client that runs in the browser and is backed by
 /// XMLHttpRequests.

--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -217,6 +217,10 @@ Client? get zoneClient {
 /// $ flutter build appbundle --dart-define=no_default_http_client=true ...
 /// $ dart compile exe --define=no_default_http_client=true ...
 /// ```
+///
+/// If `no_default_http_client=true` is set then any call to the [Client]
+/// factory (i.e. `Client()`) outside of the [Zone] created by [runWithClient]
+/// will throw [StateError].
 R runWithClient<R>(R Function() body, Client Function() clientFactory,
         {ZoneSpecification? zoneSpecification}) =>
     runZoned(body,

--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -210,6 +210,13 @@ Client? get zoneClient {
 ///  runWithClient(() => runApp(const MyApp()), clientFactory);
 /// }
 /// ```
+///
+/// If [runWithClient] is used and the environment defines
+/// `no_default_http_client=true` then generated binaries may be smaller e.g.
+/// ```shell
+/// $ flutter build appbundle --dart-define=no_default_http_client=true ...
+/// $ dart compile exe --define=no_default_http_client=true ...
+/// ```
 R runWithClient<R>(R Function() body, Client Function() clientFactory,
         {ZoneSpecification? zoneSpecification}) =>
     runZoned(body,

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -12,7 +12,13 @@ import 'io_streamed_response.dart';
 /// Create an [IOClient].
 ///
 /// Used from conditional imports, matches the definition in `client_stub.dart`.
-BaseClient createClient() => IOClient();
+BaseClient createClient() {
+  if (const bool.fromEnvironment('no_default_http_client')) {
+    throw StateError('no_default_http_client was defined but runWithClient '
+        'was not used to configure a Client implementation.');
+  }
+  return IOClient();
+}
 
 /// Exception thrown when the underlying [HttpClient] throws a
 /// [SocketException].

--- a/pkgs/http/mono_pkg.yaml
+++ b/pkgs/http/mono_pkg.yaml
@@ -15,3 +15,9 @@ stages:
   - test: --platform chrome
     os:
     - linux
+  - test: --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart
+    os:
+    - linux
+  - test: --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart
+    os:
+    - linux

--- a/pkgs/http/mono_pkg.yaml
+++ b/pkgs/http/mono_pkg.yaml
@@ -15,9 +15,6 @@ stages:
   - test: --platform chrome
     os:
     - linux
-  - test: --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart
-    os:
-    - linux
   - command: dart run --define=no_default_http_client=true test/no_default_http_client_test.dart
     os:
     - linux

--- a/pkgs/http/mono_pkg.yaml
+++ b/pkgs/http/mono_pkg.yaml
@@ -18,6 +18,6 @@ stages:
   - test: --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart
     os:
     - linux
-  - test: --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart
+  - command: dart run --define=no_default_http_client=true test/no_default_http_client_test.dart
     os:
     - linux

--- a/pkgs/http/test/no_default_http_client_test.dart
+++ b/pkgs/http/test/no_default_http_client_test.dart
@@ -10,6 +10,10 @@ import 'package:test/test.dart';
 
 void main() {
   test('Client()', () {
-    expect(() => http.Client(), throwsA(isA<StateError>()));
+    if (const bool.fromEnvironment('no_default_http_client')) {
+      expect(() => http.Client(), throwsA(isA<StateError>()));
+    } else {
+      expect(http.Client(), isA<http.Client>());
+    }
   });
 }

--- a/pkgs/http/test/no_default_http_client_test.dart
+++ b/pkgs/http/test/no_default_http_client_test.dart
@@ -2,16 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Tests that no [http.Client] is provided by default when run with
-/// `--define=no_default_http_client=true`.
-
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
 
+/// Tests that no [http.Client] is provided by default when run with
+/// `--define=no_default_http_client=true`.
 void main() {
   test('Client()', () {
     if (const bool.fromEnvironment('no_default_http_client')) {
-      expect(() => http.Client(), throwsA(isA<StateError>()));
+      expect(http.Client, throwsA(isA<StateError>()));
     } else {
       expect(http.Client(), isA<http.Client>());
     }

--- a/pkgs/http/test/no_default_http_client_test.dart
+++ b/pkgs/http/test/no_default_http_client_test.dart
@@ -10,6 +10,6 @@ import 'package:test/test.dart';
 
 void main() {
   test('Client()', () {
-    expect(http.Client, throwsA(isA<StateError>()));
+    expect(() => http.Client(), throwsA(isA<StateError>()));
   });
 }

--- a/pkgs/http/test/no_default_http_client_test.dart
+++ b/pkgs/http/test/no_default_http_client_test.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Tests that no [http.Client] is provided by default when run with
+/// `--define=no_default_http_client=true`.
+
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+void main() {
+  test('Client()', () {
+    expect(http.Client, throwsA(isA<StateError>()));
+  });
+}

--- a/pkgs/http/test/no_default_http_client_test.dart
+++ b/pkgs/http/test/no_default_http_client_test.dart
@@ -10,7 +10,7 @@ import 'package:test/test.dart';
 void main() {
   test('Client()', () {
     if (const bool.fromEnvironment('no_default_http_client')) {
-      expect(http.Client, throwsA(isA<StateError>()));
+      expect(http.Client.new, throwsA(isA<StateError>()));
     } else {
       expect(http.Client(), isA<http.Client>());
     }

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -71,6 +71,10 @@ for PKG in ${PKGS}; do
         echo 'dart analyze --fatal-infos'
         dart analyze --fatal-infos || EXIT_CODE=$?
         ;;
+      command)
+        echo 'dart run --define=no_default_http_client=true test/no_default_http_client_test.dart'
+        dart run --define=no_default_http_client=true test/no_default_http_client_test.dart || EXIT_CODE=$?
+        ;;
       format)
         echo 'dart format --output=none --set-exit-if-changed .'
         dart format --output=none --set-exit-if-changed . || EXIT_CODE=$?
@@ -86,10 +90,6 @@ for PKG in ${PKGS}; do
       test_2)
         echo 'dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart'
         dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart || EXIT_CODE=$?
-        ;;
-      test_3)
-        echo 'dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart'
-        dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart || EXIT_CODE=$?
         ;;
       *)
         echo -e "\033[31mUnknown TASK '${TASK}' - TERMINATING JOB\033[0m"

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -83,6 +83,14 @@ for PKG in ${PKGS}; do
         echo 'dart test --platform chrome'
         dart test --platform chrome || EXIT_CODE=$?
         ;;
+      test_2)
+        echo 'dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart'
+        dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart || EXIT_CODE=$?
+        ;;
+      test_3)
+        echo 'dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart'
+        dart test --platform chrome --define=no_default_http_client=true test/no_default_http_client_test.dart || EXIT_CODE=$?
+        ;;
       *)
         echo -e "\033[31mUnknown TASK '${TASK}' - TERMINATING JOB\033[0m"
         exit 64

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -87,10 +87,6 @@ for PKG in ${PKGS}; do
         echo 'dart test --platform chrome'
         dart test --platform chrome || EXIT_CODE=$?
         ;;
-      test_2)
-        echo 'dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart'
-        dart test --platform vm --define=no_default_http_client=true test/no_default_http_client_test.dart || EXIT_CODE=$?
-        ;;
       *)
         echo -e "\033[31mUnknown TASK '${TASK}' - TERMINATING JOB\033[0m"
         exit 64


### PR DESCRIPTION
Currently this can save 128,624 bytes of disk space if you use a non-dart:io HttpClient.
