### PR TITLE
Remove final for headers in BaseRequest

### DIFF
--- a/pkgs/http/lib/src/base_request.dart
+++ b/pkgs/http/lib/src/base_request.dart
@@ -82,7 +82,7 @@ abstract class BaseRequest {
   // TODO(nweiz): automatically parse cookies from headers
 
   // TODO(nweiz): make this a HttpHeaders object
-  final Map<String, String> headers;
+  Map<String, String> headers;
 
   /// Whether [finalize] has been called.
   bool get finalized => _finalized;


### PR DESCRIPTION
Current headers in BaseRequest is a final porperty, users can not modify headers of a specfic request (especially to users who use send), because of this, we should make BaseRequest as a non final porperty to give users a chance to modify headers.