### PR TITLE
Corrected the spelling of "Implements" in "/http/lib/src/io_client.dart"

### DIFF
--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -17,7 +17,7 @@ BaseClient createClient() => IOClient();
 /// Exception thrown when the underlying [HttpClient] throws a
 /// [SocketException].
 ///
-/// Implemenents [SocketException] to avoid breaking existing users of
+/// Implements [SocketException] to avoid breaking existing users of
 /// [IOClient] that may catch that exception.
 class _ClientSocketException extends ClientException
     implements SocketException {


### PR DESCRIPTION
Fixed a spelling error by correcting "Implemenents" to "Implements" in "/http/lib/src/io_client.dart".
Fix #870 