### PR TITLE
Don't alter Content-Type in Request if user explicitly sets it (#184)

### DIFF
--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -83,9 +83,10 @@ class Request extends BaseRequest {
   /// This is converted to and from [bodyBytes] using [encoding].
   ///
   /// When this is set, if the request does not yet have a `Content-Type`
-  /// header, one will be added with the type `text/plain`. Then the `charset`
-  /// parameter of the `Content-Type` header (whether new or pre-existing) will
-  /// be set to [encoding] if it wasn't already set.
+  /// header, one will be added with the type `text/plain; charset=<encoding>`,
+  /// where `<encoding>` is [encoding]. If there is already a `Content-Type`
+  /// header, it will not be altered, since in this case, it is the users
+  /// responsibility to correctly set it.
   String get body => encoding.decode(bodyBytes);
 
   set body(String value) {
@@ -93,8 +94,6 @@ class Request extends BaseRequest {
     var contentType = _contentType;
     if (contentType == null) {
       _contentType = MediaType('text', 'plain', {'charset': encoding.name});
-    } else if (!contentType.parameters.containsKey('charset')) {
-      _contentType = contentType.change(parameters: {'charset': encoding.name});
     }
   }
 


### PR DESCRIPTION
I'm using this library and came across a very frustrating bug, see #184.
The core problem is, that this library alters the Content-Type header I (as a developer) explicitly set.
This is dangerous behaviour and should be removed.