### PR TITLE
🐛 Fix the missing quotes for the implementation

### DIFF
--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -83,7 +83,7 @@ void updateCronetDependency(String latestVersion) {
   print('Patching $newImplementation');
   final newGradleContent = gradleContent.replaceAll(
     implementationRegExp,
-    '    implementation $newImplementation',
+    '    implementation "$newImplementation"',
   );
   fBuildGradle.writeAsStringSync(newGradleContent);
 }


### PR DESCRIPTION
The quotes are missing from the replaced `implementation` line, which makes the plugin completely unable to run.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
