### PR TITLE
Make StreameRequest.sink a StreamSink

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.0.1
+## 1.1.0-wip
 
-* Add better error messages for `SocketException`s when using `IOClient`. 
- 
+* Add better error messages for `SocketException`s when using `IOClient`.
+* Make `StreamedRequest.sink` a `StreamSink`.
+
 ## 1.0.0
 
 * Requires Dart 3.0 or later.

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.1.0-wip
 
 * Add better error messages for `SocketException`s when using `IOClient`.
-* Make `StreamedRequest.sink` a `StreamSink`.
+* Make `StreamedRequest.sink` a `StreamSink`. This makes `request.sink.close()`
+  return a `Future` instead of `void`, but the returned future should _not_ be
+  awaited. The Future returned from `sink.close()` may only complete after the
+  request has been sent.
 
 ## 1.0.0
 

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'base_client.dart';
@@ -95,9 +94,7 @@ class IOClient extends BaseClient {
         ioRequest.headers.set(name, value);
       });
 
-      // var response = await stream.pipe(ioRequest) as HttpClientResponse;
-      unawaited(stream.pipe(ioRequest));
-      var response = await ioRequest.done;
+      var response = await stream.pipe(ioRequest) as HttpClientResponse;
 
       var headers = <String, String>{};
       response.headers.forEach((key, values) {

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'base_client.dart';
@@ -94,7 +95,9 @@ class IOClient extends BaseClient {
         ioRequest.headers.set(name, value);
       });
 
-      var response = await stream.pipe(ioRequest) as HttpClientResponse;
+      // var response = await stream.pipe(ioRequest) as HttpClientResponse;
+      unawaited(stream.pipe(ioRequest));
+      var response = await ioRequest.done;
 
       var headers = <String, String>{};
       response.headers.forEach((key, values) {

--- a/pkgs/http/lib/src/streamed_request.dart
+++ b/pkgs/http/lib/src/streamed_request.dart
@@ -24,13 +24,10 @@ import 'byte_stream.dart';
 ///
 /// // The sink must be closed to end the request.
 /// // The Future returned from `close()` may not complete until after the
-/// request is sent, an it generally should not be awaited.
+/// // request is sent, and it should not be awaited.
 /// unawaited(request.sink.close());
 /// final response = await request.send();
 /// ```
-///
-/// The `Future` returned from calling `sink.close()` will not complete until
-/// the request has been sent.
 class StreamedRequest extends BaseRequest {
   /// The sink to which to write data that will be sent as the request body.
   ///

--- a/pkgs/http/lib/src/streamed_request.dart
+++ b/pkgs/http/lib/src/streamed_request.dart
@@ -20,11 +20,17 @@ import 'byte_stream.dart';
 /// ```dart
 /// final request = http.StreamedRequest('POST', Uri.http('example.com', ''))
 ///     ..contentLength = 10
-///     ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-///     ..sink.close();  // The sink must be closed to end the request.
+///     ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 ///
+/// // The sink must be closed to end the request.
+/// // The Future returned from `close()` may not complete until after the
+/// request is sent, an it generally should not be awaited.
+/// unawaited(request.sink.close());
 /// final response = await request.send();
 /// ```
+///
+/// The `Future` returned from calling `sink.close()` will not complete until
+/// the request has been sent.
 class StreamedRequest extends BaseRequest {
   /// The sink to which to write data that will be sent as the request body.
   ///

--- a/pkgs/http/lib/src/streamed_request.dart
+++ b/pkgs/http/lib/src/streamed_request.dart
@@ -32,7 +32,7 @@ class StreamedRequest extends BaseRequest {
   /// buffered.
   ///
   /// Closing this signals the end of the request.
-  EventSink<List<int>> get sink => _controller.sink;
+  StreamSink<List<int>> get sink => _controller.sink;
 
   /// The controller for [sink], from which [BaseRequest] will read data for
   /// [finalize].

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 1.0.1-wip
+version: 1.1.0-wip
 description: A composable, multi-platform, Future-based API for HTTP requests.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http
 

--- a/pkgs/http/test/html/client_test.dart
+++ b/pkgs/http/test/html/client_test.dart
@@ -5,6 +5,8 @@
 @TestOn('browser')
 library;
 
+import 'dart:async';
+
 import 'package:http/browser_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
@@ -18,7 +20,7 @@ void main() {
 
     var responseFuture = client.send(request);
     request.sink.add('{"hello": "world"}'.codeUnits);
-    await request.sink.close();
+    unawaited(request.sink.close());
 
     var response = await responseFuture;
     var bytesString = await response.stream.bytesToString();

--- a/pkgs/http/test/html/client_test.dart
+++ b/pkgs/http/test/html/client_test.dart
@@ -17,9 +17,8 @@ void main() {
     var request = http.StreamedRequest('POST', echoUrl);
 
     var responseFuture = client.send(request);
-    request.sink
-      ..add('{"hello": "world"}'.codeUnits)
-      ..close();
+    request.sink.add('{"hello": "world"}'.codeUnits);
+    await request.sink.close();
 
     var response = await responseFuture;
     var bytesString = await response.stream.bytesToString();

--- a/pkgs/http/test/html/streamed_request_test.dart
+++ b/pkgs/http/test/html/streamed_request_test.dart
@@ -5,6 +5,8 @@
 @TestOn('browser')
 library;
 
+import 'dart:async';
+
 import 'package:http/browser_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:test/test.dart';
@@ -17,7 +19,7 @@ void main() {
       var request = http.StreamedRequest('POST', echoUrl)
         ..contentLength = 10
         ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      await request.sink.close();
+      unawaited(request.sink.close());
 
       final response = await BrowserClient().send(request);
 
@@ -28,7 +30,7 @@ void main() {
     test("works when it's not set", () async {
       var request = http.StreamedRequest('POST', echoUrl);
       request.sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      await request.sink.close();
+      unawaited(request.sink.close());
 
       final response = await BrowserClient().send(request);
       expect(await response.stream.toBytes(),

--- a/pkgs/http/test/html/streamed_request_test.dart
+++ b/pkgs/http/test/html/streamed_request_test.dart
@@ -16,8 +16,8 @@ void main() {
     test("works when it's set", () async {
       var request = http.StreamedRequest('POST', echoUrl)
         ..contentLength = 10
-        ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-        ..sink.close();
+        ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      await request.sink.close();
 
       final response = await BrowserClient().send(request);
 
@@ -28,7 +28,7 @@ void main() {
     test("works when it's not set", () async {
       var request = http.StreamedRequest('POST', echoUrl);
       request.sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      request.sink.close();
+      await request.sink.close();
 
       final response = await BrowserClient().send(request);
       expect(await response.stream.toBytes(),

--- a/pkgs/http/test/io/client_test.dart
+++ b/pkgs/http/test/io/client_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -43,7 +44,7 @@ void main() {
 
     var responseFuture = client.send(request);
     request.sink.add('{"hello": "world"}'.codeUnits);
-    await request.sink.close();
+    unawaited(request.sink.close());
 
     var response = await responseFuture;
 
@@ -81,7 +82,7 @@ void main() {
 
     var responseFuture = client.send(request);
     request.sink.add('{"hello": "world"}'.codeUnits);
-    await request.sink.close();
+    unawaited(request.sink.close());
 
     var response = await responseFuture;
 

--- a/pkgs/http/test/io/client_test.dart
+++ b/pkgs/http/test/io/client_test.dart
@@ -42,9 +42,8 @@ void main() {
       ..headers[HttpHeaders.userAgentHeader] = 'Dart';
 
     var responseFuture = client.send(request);
-    request
-      ..sink.add('{"hello": "world"}'.codeUnits)
-      ..sink.close();
+    request.sink.add('{"hello": "world"}'.codeUnits);
+    await request.sink.close();
 
     var response = await responseFuture;
 
@@ -81,9 +80,8 @@ void main() {
       ..headers[HttpHeaders.userAgentHeader] = 'Dart';
 
     var responseFuture = client.send(request);
-    request
-      ..sink.add('{"hello": "world"}'.codeUnits)
-      ..sink.close();
+    request.sink.add('{"hello": "world"}'.codeUnits);
+    await request.sink.close();
 
     var response = await responseFuture;
 

--- a/pkgs/http/test/io/streamed_request_test.dart
+++ b/pkgs/http/test/io/streamed_request_test.dart
@@ -22,8 +22,8 @@ void main() {
     test('controls the Content-Length header', () async {
       var request = http.StreamedRequest('POST', serverUrl)
         ..contentLength = 10
-        ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-        ..sink.close();
+        ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+      await request.sink.close();
 
       var response = await request.send();
       expect(
@@ -35,7 +35,7 @@ void main() {
     test('defaults to sending no Content-Length', () async {
       var request = http.StreamedRequest('POST', serverUrl);
       request.sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      request.sink.close();
+      await request.sink.close();
 
       var response = await request.send();
       expect(await utf8.decodeStream(response.stream),
@@ -47,7 +47,7 @@ void main() {
   test('.send() with a response with no content length', () async {
     var request =
         http.StreamedRequest('GET', serverUrl.resolve('/no-content-length'));
-    request.sink.close();
+    await request.sink.close();
     var response = await request.send();
     expect(await utf8.decodeStream(response.stream), equals('body'));
   });

--- a/pkgs/http/test/io/streamed_request_test.dart
+++ b/pkgs/http/test/io/streamed_request_test.dart
@@ -25,7 +25,6 @@ void main() {
         ..contentLength = 10
         ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       unawaited(request.sink.close());
-
       var response = await request.send();
       expect(
           await utf8.decodeStream(response.stream),
@@ -37,7 +36,6 @@ void main() {
       var request = http.StreamedRequest('POST', serverUrl);
       request.sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
       unawaited(request.sink.close());
-
       var response = await request.send();
       expect(await utf8.decodeStream(response.stream),
           parse(containsPair('headers', isNot(contains('content-length')))));

--- a/pkgs/http/test/io/streamed_request_test.dart
+++ b/pkgs/http/test/io/streamed_request_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
@@ -23,7 +24,7 @@ void main() {
       var request = http.StreamedRequest('POST', serverUrl)
         ..contentLength = 10
         ..sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      await request.sink.close();
+      unawaited(request.sink.close());
 
       var response = await request.send();
       expect(
@@ -35,7 +36,7 @@ void main() {
     test('defaults to sending no Content-Length', () async {
       var request = http.StreamedRequest('POST', serverUrl);
       request.sink.add([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-      await request.sink.close();
+      unawaited(request.sink.close());
 
       var response = await request.send();
       expect(await utf8.decodeStream(response.stream),
@@ -47,7 +48,7 @@ void main() {
   test('.send() with a response with no content length', () async {
     var request =
         http.StreamedRequest('GET', serverUrl.resolve('/no-content-length'));
-    await request.sink.close();
+    unawaited(request.sink.close());
     var response = await request.send();
     expect(await utf8.decodeStream(response.stream), equals('body'));
   });


### PR DESCRIPTION
Closes #727

This class was not designed for extension, but there is at least one
extending implementation. I don't see any overrides of this field, so no
existing usage should be broken.
