### PR TITLE
Ignore generated flutter plugin files

### DIFF
--- a/pkgs/java_http/.gitignore
+++ b/pkgs/java_http/.gitignore
@@ -1,1 +1,3 @@
 build/
+.flutter-plugins
+.flutter-plugins-dependencies


### PR DESCRIPTION
These files both start with comments stating that they should not be
edited by hand nor checked into source control. Add them to the
`.gitignore`.
