### PR TITLE
Add java_http .gitattributes file

### DIFF
--- a/pkgs/java_http/.gitattributes
+++ b/pkgs/java_http/.gitattributes
@@ -1,0 +1,2 @@
+# Hides jnigen generated code in GitHub diffs.
+lib/src/third_party/** linguist-generated

--- a/pkgs/java_http/.gitattributes
+++ b/pkgs/java_http/.gitattributes
@@ -1,2 +1,2 @@
-# Hides jnigen generated code in GitHub diffs.
-lib/src/third_party/** linguist-generated
+# Vendored code is excluded from language stats in the GitHub repo.
+lib/src/third_party/** linguist-vendored

--- a/pkgs/java_http/.gitattributes
+++ b/pkgs/java_http/.gitattributes
@@ -1,2 +1,5 @@
 # Vendored code is excluded from language stats in the GitHub repo.
 lib/src/third_party/** linguist-vendored
+
+# jnigen generated code is hidden in GitHub diffs.
+lib/src/third_party/java/** linguist-generated


### PR DESCRIPTION
This is a PR for the `java_http` [GSoC '23 project](https://summerofcode.withgoogle.com/programs/2023/projects/NKUQqmSA) 🌞.
Relevant tracking issue: https://github.com/dart-lang/http/issues/957.

## Purpose
The purpose of this PR is to make `jnigen` generated code in `java_http` hidden by default in GitHub diffs.
`cronet_http` and `cupertino_http` already hide their generated files in GitHub diffs:
- [`cronet_http`'s .gitattributes](https://github.com/dart-lang/http/blob/1a42b4a16636e86b5fed60666b0de91219c5110c/pkgs/cronet_http/.gitattributes)
- [`cupertino_http`'s .gitattributes](https://github.com/dart-lang/http/blob/1a42b4a16636e86b5fed60666b0de91219c5110c/pkgs/cupertino_http/.gitattributes)

This PR makes `java_http` have the same behaviour as the other `package:http` clients by hiding generated code in GitHub diffs.

## Reviewers
@natebosch

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>