### PR TITLE
fix: missing HTTP method in cronet client

### DIFF
--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -332,6 +332,7 @@ class CronetClient extends BaseClient {
       builder.setUploadDataProvider(
           jb.UploadDataProviders.create2(body.toJByteBuffer()), _executor);
     }
+    builder.setHttpMethod(request.method.toJString());
     builder.build().start();
     return responseCompleter.future;
   }


### PR DESCRIPTION
In `send` function of `CronetClient`, HTTP method in request is never set to the builder. With default behavior, Cronet will use `GET` when there's no body and `POST` otherwise, so every `PUT` request will become `POST`.

This PR just set the missing HTTP method to the builder.