### PR TITLE
Add a skeleton "http_profile" package

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v6.5.7
+# Created with package:mono_repo v6.6.0
 name: Dart CI
 on:
   push:
@@ -36,7 +36,7 @@ jobs:
         name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 6.5.7
+        run: dart pub global activate mono_repo 6.6.0
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -70,16 +70,16 @@ jobs:
         if: "always() && steps.pkgs_http_client_conformance_tests_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http_client_conformance_tests
   job_003:
-    name: "analyze_and_format; Dart 3.0.0; PKG: pkgs/http; `dart analyze --fatal-infos`"
+    name: "analyze_and_format; Dart 3.0.0; PKGS: pkgs/http, pkgs/http_profile; `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http-pkgs/http_profile;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http-pkgs/http_profile
             os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -99,17 +99,26 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http
+      - id: pkgs_http_profile_pub_upgrade
+        name: pkgs/http_profile; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http_profile
+      - name: "pkgs/http_profile; dart analyze --fatal-infos"
+        run: dart analyze --fatal-infos
+        if: "always() && steps.pkgs_http_profile_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http_profile
   job_004:
-    name: "analyze_and_format; Dart dev; PKGS: pkgs/http, pkgs/http_client_conformance_tests; `dart analyze --fatal-infos`"
+    name: "analyze_and_format; Dart dev; PKGS: pkgs/http, pkgs/http_client_conformance_tests, pkgs/http_profile; `dart analyze --fatal-infos`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests-pkgs/http_profile;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests-pkgs/http_profile
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -138,17 +147,26 @@ jobs:
         run: dart analyze --fatal-infos
         if: "always() && steps.pkgs_http_client_conformance_tests_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http_client_conformance_tests
+      - id: pkgs_http_profile_pub_upgrade
+        name: pkgs/http_profile; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http_profile
+      - name: "pkgs/http_profile; dart analyze --fatal-infos"
+        run: dart analyze --fatal-infos
+        if: "always() && steps.pkgs_http_profile_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http_profile
   job_005:
-    name: "analyze_and_format; Dart dev; PKGS: pkgs/http, pkgs/http_client_conformance_tests; `dart format --output=none --set-exit-if-changed .`"
+    name: "analyze_and_format; Dart dev; PKGS: pkgs/http, pkgs/http_client_conformance_tests, pkgs/http_profile; `dart format --output=none --set-exit-if-changed .`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests;commands:format"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests-pkgs/http_profile;commands:format"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_client_conformance_tests-pkgs/http_profile
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -177,6 +195,15 @@ jobs:
         run: "dart format --output=none --set-exit-if-changed ."
         if: "always() && steps.pkgs_http_client_conformance_tests_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http_client_conformance_tests
+      - id: pkgs_http_profile_pub_upgrade
+        name: pkgs/http_profile; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http_profile
+      - name: "pkgs/http_profile; dart format --output=none --set-exit-if-changed ."
+        run: "dart format --output=none --set-exit-if-changed ."
+        if: "always() && steps.pkgs_http_profile_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http_profile
   job_006:
     name: "unit_test; Dart 3.0.0; PKG: pkgs/http; `dart run --define=no_default_http_client=true test/no_default_http_client_test.dart`"
     runs-on: ubuntu-latest
@@ -250,16 +277,16 @@ jobs:
       - job_004
       - job_005
   job_008:
-    name: "unit_test; Dart 3.0.0; PKG: pkgs/http; `dart test --platform vm`"
+    name: "unit_test; Dart 3.0.0; PKGS: pkgs/http, pkgs/http_profile; `dart test --platform vm`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http-pkgs/http_profile;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0;packages:pkgs/http-pkgs/http_profile
             os:ubuntu-latest;pub-cache-hosted;sdk:3.0.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -279,6 +306,15 @@ jobs:
         run: dart test --platform vm
         if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http
+      - id: pkgs_http_profile_pub_upgrade
+        name: pkgs/http_profile; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http_profile
+      - name: "pkgs/http_profile; dart test --platform vm"
+        run: dart test --platform vm
+        if: "always() && steps.pkgs_http_profile_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http_profile
     needs:
       - job_001
       - job_002
@@ -358,16 +394,16 @@ jobs:
       - job_004
       - job_005
   job_011:
-    name: "unit_test; Dart dev; PKG: pkgs/http; `dart test --platform vm`"
+    name: "unit_test; Dart dev; PKGS: pkgs/http, pkgs/http_profile; `dart test --platform vm`"
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http;commands:test_0"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_profile;commands:test_0"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:pkgs/http-pkgs/http_profile
             os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -387,6 +423,15 @@ jobs:
         run: dart test --platform vm
         if: "always() && steps.pkgs_http_pub_upgrade.conclusion == 'success'"
         working-directory: pkgs/http
+      - id: pkgs_http_profile_pub_upgrade
+        name: pkgs/http_profile; dart pub upgrade
+        run: dart pub upgrade
+        if: "always() && steps.checkout.conclusion == 'success'"
+        working-directory: pkgs/http_profile
+      - name: "pkgs/http_profile; dart test --platform vm"
+        run: dart test --platform vm
+        if: "always() && steps.pkgs_http_profile_pub_upgrade.conclusion == 'success'"
+        working-directory: pkgs/http_profile
     needs:
       - job_001
       - job_002

--- a/pkgs/http_profile/CHANGELOG.md
+++ b/pkgs/http_profile/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* Skeleton class and test definitions.

--- a/pkgs/http_profile/LICENSE
+++ b/pkgs/http_profile/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2023, the Dart project authors. 
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google LLC nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkgs/http_profile/README.md
+++ b/pkgs/http_profile/README.md
@@ -1,0 +1,2 @@
+An **experimental** package that allows HTTP clients outside of the Dart SDK
+to integrate with the DevTools Network tab.

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+/// Records information about an HTTP request.
+final class HttpClientRequestProfile {
+  /// Determines whether HTTP profiling is enabled or not.
+  ///
+  /// The value can be changed programmatically or through the DevTools Network
+  /// UX.
+  static bool get profilingEnabled => HttpClient.enableTimelineLogging;
+  static set profilingEnabled(bool enabled) =>
+      HttpClient.enableTimelineLogging = enabled;
+
+  String? requestMethod;
+  String? requestUri;
+
+  HttpClientRequestProfile._();
+
+  /// If HTTP profiling is enabled, returns
+  /// a [HttpClientRequestProfile] otherwise returns `null`.
+  static HttpClientRequestProfile? profile() {
+    // Always return `null` in product mode so that the
+    // profiling code can be tree shaken away.
+    if (const bool.fromEnvironment('dart.vm.product') || !profilingEnabled) {
+      return null;
+    }
+    final requestProfile = HttpClientRequestProfile._();
+    return requestProfile;
+  }
+}

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 /// Records information about an HTTP request.

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 /// Records information about an HTTP request.
 final class HttpClientRequestProfile {
-  /// Determines whether HTTP profiling is enabled or not.
+  /// Whether HTTP profiling is enabled or not.
   ///
   /// The value can be changed programmatically or through the DevTools Network
   /// UX.

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-/// Records information about an HTTP request.
+/// A record of debugging information about an HTTP request.
 final class HttpClientRequestProfile {
   /// Whether HTTP profiling is enabled or not.
   ///

--- a/pkgs/http_profile/mono_pkg.yaml
+++ b/pkgs/http_profile/mono_pkg.yaml
@@ -1,0 +1,14 @@
+sdk:
+- pubspec
+- dev
+
+stages:
+- analyze_and_format:
+  - analyze: --fatal-infos
+  - format:
+    sdk:
+    - dev
+- unit_test:
+  - test: --platform vm
+    os:
+    - linux

--- a/pkgs/http_profile/pubspec.yaml
+++ b/pkgs/http_profile/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http_profile
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
   test: ^1.24.9

--- a/pkgs/http_profile/pubspec.yaml
+++ b/pkgs/http_profile/pubspec.yaml
@@ -1,0 +1,15 @@
+name: http_profile
+description: >-
+  A library used by HTTP client authors to integrate with the DevTools
+  Network tab.
+publish_to: none
+repository: https://github.com/dart-lang/http/tree/master/pkgs/http_profile
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  test: ^1.24.9
+
+dev_dependencies:
+  dart_flutter_team_lints: ^2.1.1

--- a/pkgs/http_profile/test/profiling_enabled_test.dart
+++ b/pkgs/http_profile/test/profiling_enabled_test.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:http_profile/http_profile.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('profiling enabled', () async {
+    HttpClientRequestProfile.profilingEnabled = true;
+    expect(HttpClient.enableTimelineLogging, true);
+    expect(HttpClientRequestProfile.profile(), isNotNull);
+  });
+
+  test('profiling disabled', () async {
+    HttpClientRequestProfile.profilingEnabled = false;
+    expect(HttpClient.enableTimelineLogging, false);
+    expect(HttpClientRequestProfile.profile(), isNull);
+  });
+}

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v6.5.7
+# Created with package:mono_repo v6.6.0
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
- Creates a new *experimental* `package:http_profile` (final name TBD)
- Will eventually implement the [non-SDK HTTP Client Profiling](https://docs.google.com/document/d/1kedr5KENFZyg5aEHBXvBPMtjlpM4YAoWqDtWxiOuW00/edit?usp=sharing&resourcekey=0-ZENajKyQulzEmi4I1oP53Q) design (TL;DR will allow non-SDK HTTP clients to record profiling information in a `HttpClientRequestProfile` instance and have that information displayed in the DevTools Network tab)
---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
