### PR TITLE
Fix obsolete `CronetClient()` constructor usage

### DIFF
--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Fix obsolete `CronetClient()` constructor usage.
+
 ## 0.4.0
  
 * Use more efficient operations when copying bytes between Java and Dart.

--- a/pkgs/cronet_http/lib/cronet_http.dart
+++ b/pkgs/cronet_http/lib/cronet_http.dart
@@ -10,7 +10,7 @@
 /// import 'package:cronet_http/cronet_http.dart';
 ///
 /// void main() async {
-///   var client = CronetClient();
+///   var client = CronetClient.defaultCronetEngine();
 ///   final response = await client.get(
 ///       Uri.https('www.googleapis.com', '/books/v1/volumes', {'q': '{http}'}));
 ///   if (response.statusCode != 200) {

--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -235,7 +235,7 @@ jb.UrlRequestCallbackProxy_UrlRequestCallbackInterface _urlRequestCallbacks(
 /// For example:
 /// ```
 /// void main() async {
-///   var client = CronetClient();
+///   var client = CronetClient.defaultCronetEngine();
 ///   final response = await client.get(
 ///       Uri.https('www.googleapis.com', '/books/v1/volumes', {'q': '{http}'}));
 ///   if (response.statusCode != 200) {

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cronet_http
 description: >
   An Android Flutter plugin that provides access to the Cronet HTTP client.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http
 
 environment:


### PR DESCRIPTION
- Replace usage of `CronetClient()` with `CronetClient.defaultCronetEngine()`
- Fixes https://github.com/dart-lang/http/issues/1039
---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
