### PR TITLE
Require a package:jni version without known buffer overflows

### DIFF
--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+* Require `package:jni >= 0.7.2` to remove a potential buffer overflow.
+
 ## 0.4.1
  
 * Require `package:jni >= 0.7.1` so that depending on `package:cronet_http` 

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cronet_http
 description: >
   An Android Flutter plugin that provides access to the Cronet HTTP client.
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: '>=0.13.4 <2.0.0'
-  jni: ^0.7.1
+  jni: ^0.7.2
 
 dev_dependencies:
   dart_flutter_team_lints: ^1.0.0


### PR DESCRIPTION
- `package:jni` 0.7.1 has a potential buffer overflow when converting Java to Dart strings.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
