### PR TITLE
Document how to use replacement `Client` implementations

### DIFF
--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -100,3 +100,50 @@ and increases the delay by 1.5x each time. All of this can be customized using
 the [`RetryClient()`][new RetryClient] constructor.
 
 [new RetryClient]: https://pub.dev/documentation/http/latest/retry/RetryClient/RetryClient.html
+
+## Chosing an implementation
+
+There are multiple implementations of the `package:http` `Client` interface.
+You can chose which implementation to use based on the needs of your
+application. You can change implementations without changing your application
+code, except for a few lines of [configuration]().
+
+Some well supported implementations are:
+
+| Implementation | Supported Platforms | Supports Caching | Supports HTTP3/QUIC | Platform Native |
+| -------------- | ------------------- | ---------------- | ------------------- | --------------- |
+| `package:http` — [`IOClient`][ioclient] | Android, iOS, Linux, macOS, Windows | ❌ | ❌ | ❌ |
+| `package:http` — [`BrowserClient`][browserclient] | Web | ― | ✅︎ | ✅︎ |
+| [`package:cupertino_http`][cupertinohttp] — [`CupertinoClient`][cupertinoclient] | iOS, macOS | ✅︎ | ✅︎ | ✅︎ |
+| [`package:cronet_http`][cronethttp] — [`CronetClient`][cronetclient] | Android | ✅︎ | ✅︎ | ― |
+| [`package:fetch_client`][fetch] — [`FetchClient`][fetchclient] | Web | ✅︎ | ✅︎ | ✅︎ |
+
+
+[ioclient]: https://pub.dev/documentation/http/latest/io_client/IOClient-class.html
+[browserclient]: https://pub.dev/documentation/http/latest/browser_client/BrowserClient-class.html
+[cupertinohttp]: https://pub.dev/packages/cupertino_http
+[cupertinoclient]: https://pub.dev/documentation/cupertino_http/latest/cupertino_http/CupertinoClient-class.html
+[cronethttp]: https://pub.dev/packages/cronet_http
+[cronetclient]: https://pub.dev/documentation/cronet_http/latest/cronet_http/CronetClient-class.html
+[fetch]: https://pub.dev/packages/fetch_client
+[fetchclient]: https://pub.dev/documentation/fetch_client/latest/fetch_client/FetchClient-class.html
+
+## Configuration
+
+```terminal
+flutter pub add http
+```
+
+
+```
+late Client client;
+if (Platform.isIOS) {
+  final config = URLSessionConfiguration.ephemeralSessionConfiguration()
+    ..allowsCellularAccess = false
+    ..allowsConstrainedNetworkAccess = false
+    ..allowsExpensiveNetworkAccess = false;
+  client = CupertinoClient.fromSessionConfiguration(config);
+} else {
+  client = IOClient(); // Uses an HTTP client based on dart:io
+}
+```

--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -244,13 +244,13 @@ For example:
 
 ```dart
 void main() {
-  var client = httpClient();
+  final client = httpClient();
   fetchAlbum(client, ...);
 }
 ```
 
-In Flutter, you can use [`package:provider`][provider] to make the correct
-[`Client`][client] availble to `State` objects.
+In Flutter, you can use a one of many
+[state mangement approaches][flutterstatemanagement].
 
 If you depend on code that uses top-level functions (e.g. `http.post`) or
 calls the [`Client()`][clientconstructor] constructor, then you can use
@@ -273,5 +273,6 @@ calls the [`Client()`][clientconstructor] constructor, then you can use
 [fetchclient]: https://pub.dev/documentation/fetch_client/latest/fetch_client/FetchClient-class.html
 [flutterhttpexample]: https://github.com/dart-lang/http/tree/master/pkgs/flutter_http_example
 [ioclient]: https://pub.dev/documentation/http/latest/io_client/IOClient-class.html
+[flutterstatemanagement]: https://docs.flutter.dev/data-and-backend/state-mgmt/options
 [provider]: https://pub.dev/packages/provider
 [runwithclient]: https://pub.dev/documentation/http/latest/http/runWithClient.html

--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -50,7 +50,7 @@ try {
 > For detailed background information and practical usage examples, see:
 > - [Dart Development: Fetch data from the internet](https://dart.dev/tutorials/server/fetch-data)
 > - [Flutter Cookbook: Fetch data from the internet](https://docs.flutter.dev/cookbook/networking/fetch-data)
-> - [Flutter `package:http` example][flutterhttpexample]
+> - [The Flutter HTTP example application][flutterhttpexample]
 
 You can also exert more fine-grained control over your requests and responses by
 creating [Request][] or [StreamedRequest][] objects yourself and passing them to
@@ -237,7 +237,7 @@ import 'http_client_factory.dart'
 
 ### 3. Connect the HTTP client to the code that uses it.
 
-The best way to pass [`Client`s][client] to the places that use them is
+The best way to pass [`Client`][client] to the places that use it is
 explicitly through arguments.
 
 For example:
@@ -253,7 +253,7 @@ In Flutter, you can use [`package:provider`][provider] to make the correct
 [`Client`][client] availble to `State` objects.
 
 If you depend on code that uses top-level functions (e.g. `http.post`) or
-calls the [`Client()`] constructor, then you can use
+calls the [`Client()`][clientconstructor] constructor, then you can use
 [`runWithClient`](runwithclient) to ensure that the correct
 [`Client`][client] is used.
 
@@ -264,6 +264,7 @@ calls the [`Client()`] constructor, then you can use
 
 [browserclient]: https://pub.dev/documentation/http/latest/browser_client/BrowserClient-class.html
 [client]: https://pub.dev/documentation/http/latest/http/Client-class.html
+[clientconstructor]: https://pub.dev/documentation/http/latest/http/Client/Client.html
 [cupertinohttp]: https://pub.dev/packages/cupertino_http
 [cupertinoclient]: https://pub.dev/documentation/cupertino_http/latest/cupertino_http/CupertinoClient-class.html
 [cronethttp]: https://pub.dev/packages/cronet_http

--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -244,7 +244,7 @@ For example:
 
 ```dart
 void main() {
-  Client client = httpClient();
+  var client = httpClient();
   fetchAlbum(client, ...);
 }
 ```

--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -9,6 +9,11 @@ and the browser.
 
 ## Using
 
+> [!TIP]
+> The Dart [Fetch data from the internet](https://dart.dev/tutorials/server/fetch-data) and Flutter
+> [Networking Cookbook](https://docs.flutter.dev/data-and-backend/networking) have more detailed
+> examples.
+
 The easiest way to use this library is via the top-level functions. They allow
 you to make individual HTTP requests with minimal hassle:
 
@@ -101,7 +106,7 @@ the [`RetryClient()`][new RetryClient] constructor.
 
 [new RetryClient]: https://pub.dev/documentation/http/latest/retry/RetryClient/RetryClient.html
 
-## Chosing an implementation
+## Choosing an implementation
 
 There are multiple implementations of the `package:http` `Client` interface.
 You can chose which implementation to use based on the needs of your
@@ -110,13 +115,13 @@ code, except for a few lines of [configuration]().
 
 Some well supported implementations are:
 
-| Implementation | Supported Platforms | Supports Caching | Supports HTTP3/QUIC | Platform Native |
-| -------------- | ------------------- | ---------------- | ------------------- | --------------- |
-| `package:http` — [`IOClient`][ioclient] | Android, iOS, Linux, macOS, Windows | ❌ | ❌ | ❌ |
-| `package:http` — [`BrowserClient`][browserclient] | Web | ― | ✅︎ | ✅︎ |
-| [`package:cupertino_http`][cupertinohttp] — [`CupertinoClient`][cupertinoclient] | iOS, macOS | ✅︎ | ✅︎ | ✅︎ |
-| [`package:cronet_http`][cronethttp] — [`CronetClient`][cronetclient] | Android | ✅︎ | ✅︎ | ― |
-| [`package:fetch_client`][fetch] — [`FetchClient`][fetchclient] | Web | ✅︎ | ✅︎ | ✅︎ |
+| Implementation | Supported Platforms | SDK | Caching | HTTP3/QUIC | Platform Native | 
+| -------------- | ------------------- | ----| ------- | ---------- | --------------- |
+| `package:http` — [`IOClient`][ioclient] | Android, iOS, Linux, macOS, Windows | Dart, Flutter | ❌ | ❌ | ❌ |
+| `package:http` — [`BrowserClient`][browserclient] | Web | Flutter | ― | ✅︎ | ✅︎ | Dart, Flutter |
+| [`package:cupertino_http`][cupertinohttp] — [`CupertinoClient`][cupertinoclient] | iOS, macOS | Flutter | ✅︎ | ✅︎ | ✅︎ |
+| [`package:cronet_http`][cronethttp] — [`CronetClient`][cronetclient] | Android | Flutter | ✅︎ | ✅︎ | ― |
+| [`package:fetch_client`][fetch] — [`FetchClient`][fetchclient] | Web | Dart, Flutter | ✅︎ | ✅︎ | ✅︎ |
 
 
 [ioclient]: https://pub.dev/documentation/http/latest/io_client/IOClient-class.html


### PR DESCRIPTION
- Document how to use alternative `package:http` `Client` implementations including:
  - `package:cronet_http`
  - `package:cupertino_http`
  - `package:fetch_client`
- Link to Flutter/Dart HTTP tutorials
- Link to HTTP setup information for Flutter

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
