### PR TITLE
Add documentation for "no_default_http_client"

### DIFF
--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -255,7 +255,17 @@ In Flutter, you can use a one of many
 If you depend on code that uses top-level functions (e.g. `http.post`) or
 calls the [`Client()`][clientconstructor] constructor, then you can use
 [`runWithClient`](runwithclient) to ensure that the correct
-[`Client`][client] is used.
+`Client` is used.
+
+You can ensure that only the `Client` that you have explicitly configured is
+used by defining `no_default_http_client=true` in the environment. This will
+also allow the default `Client` implementation to be removed, resulting in
+a reduced application size.
+
+```terminal
+$ flutter build appbundle --dart-define=no_default_http_client=true ...
+$ dart compile exe --define=no_default_http_client=true ...
+```
 
 > [!TIP]
 > [The Flutter HTTP example application][flutterhttpexample] demonstrates


### PR DESCRIPTION
- Explain how "no_default_http_client=true" can be defined in the environment to save disk space and ensure that only the configured `Client` is used.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
