### PR TITLE
Document that runWithClient must be called for every isolate

### DIFF
--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -255,8 +255,9 @@ In Flutter, you can use a one of many
 If you depend on code that uses top-level functions (e.g. `http.post`) or
 calls the [`Client()`][clientconstructor] constructor, then you can use
 [`runWithClient`](runwithclient) to ensure that the correct
-`Client` is used. Since [isolates][isolate] cannot share mutable state, you
-must call [`runWithClient`](runwithclient) at the start of every isolate.
+`Client` is used. When an [Isolate][isolate] is spawned, it does not inherit
+any variables from the calling Zone, so `runWithClient` needs to be used in
+each Isolate that uses `package:http`.
 
 You can ensure that only the `Client` that you have explicitly configured is
 used by defining `no_default_http_client=true` in the environment. This will

--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -255,7 +255,8 @@ In Flutter, you can use a one of many
 If you depend on code that uses top-level functions (e.g. `http.post`) or
 calls the [`Client()`][clientconstructor] constructor, then you can use
 [`runWithClient`](runwithclient) to ensure that the correct
-`Client` is used.
+`Client` is used. Since [isolates][isolate] cannot share mutable state, you
+must call [`runWithClient`](runwithclient) at the start of every isolate.
 
 You can ensure that only the `Client` that you have explicitly configured is
 used by defining `no_default_http_client=true` in the environment. This will
@@ -283,6 +284,7 @@ $ dart compile exe --define=no_default_http_client=true ...
 [fetchclient]: https://pub.dev/documentation/fetch_client/latest/fetch_client/FetchClient-class.html
 [flutterhttpexample]: https://github.com/dart-lang/http/tree/master/pkgs/flutter_http_example
 [ioclient]: https://pub.dev/documentation/http/latest/io_client/IOClient-class.html
+[isolate]: https://dart.dev/language/concurrency#how-isolates-work
 [flutterstatemanagement]: https://docs.flutter.dev/data-and-backend/state-mgmt/options
 [provider]: https://pub.dev/packages/provider
 [runwithclient]: https://pub.dev/documentation/http/latest/http/runWithClient.html


### PR DESCRIPTION
- Document that runWithClient must be called for every isolate

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
