### PR TITLE
[http] ✨ Add `redirects` in `IOStreamedResponse`

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3-wip
+
+* Add `redirects` in `IOStreamedResponse`.
+
 ## 1.1.2
 
 * Allow `web: '>=0.3.0 <0.5.0'`.

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -127,6 +127,7 @@ class IOClient extends BaseClient {
           request: request,
           headers: headers,
           isRedirect: response.isRedirect,
+          redirects: response.redirects,
           persistentConnection: response.persistentConnection,
           reasonPhrase: response.reasonPhrase,
           inner: response);

--- a/pkgs/http/lib/src/io_streamed_response.dart
+++ b/pkgs/http/lib/src/io_streamed_response.dart
@@ -23,8 +23,15 @@ class IOStreamedResponse extends StreamedResponse {
       super.isRedirect,
       super.persistentConnection,
       super.reasonPhrase,
+      this.redirects = const [],
       HttpClientResponse? inner})
       : _inner = inner;
+
+  /// Returns the series of redirects this connection has been through.
+  /// The list will be empty if no redirects were followed.
+  /// [redirects] will be updated both in the case of
+  /// an automatic and a manual redirect.
+  final List<RedirectInfo> redirects;
 
   /// Detaches the underlying socket from the HTTP server.
   ///

--- a/pkgs/http/test/io/request_test.dart
+++ b/pkgs/http/test/io/request_test.dart
@@ -5,7 +5,10 @@
 @TestOn('vm')
 library;
 
+import 'dart:io';
+
 import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart' as http_io;
 import 'package:test/test.dart';
 
 import '../utils.dart';
@@ -64,5 +67,15 @@ void main() {
         request.send(),
         throwsA(isA<http.ClientException>()
             .having((e) => e.message, 'message', 'Redirect limit exceeded')));
+  });
+
+  test('contains redirects', () async {
+    var ioClient = HttpClient();
+    var client = http_io.IOClient(ioClient);
+    var request = http.Request('GET', serverUrl.resolve('/redirect'));
+    var response = await client.send(request);
+    expect(response.statusCode, equals(200));
+    expect(response.redirects.length, equals(1));
+    expect(response.redirects.first.location, serverUrl.resolve('/'));
   });
 }


### PR DESCRIPTION
The request provides the ability to extract the redirections from an `IOStreamedResponse`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
