### PR TITLE
cronet_http: require android API level 28

### DIFF
--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -6,12 +6,12 @@ on:
       - main
       - master
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/cronet.yaml'
       - 'pkgs/cronet_http/**'
       - 'pkgs/http_client_conformance_tests/**'
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/cronet.yaml'
       - 'pkgs/cronet_http/**'
       - 'pkgs/http_client_conformance_tests/**'
   schedule:
@@ -58,8 +58,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         if: always() && steps.install.outcome == 'success'
         with:
-          api-level: 28
-          target: ${{ matrix.package == 'cronet_http_embedded' && 'default' || 'playstore' }}
+          api-level: 19
+          target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           arch: x86_64
           profile: pixel
           script: cd 'pkgs/${{ matrix.package }}/example' && flutter test --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -58,8 +58,10 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         if: always() && steps.install.outcome == 'success'
         with:
-          # This should match the minSdkVersion in
-          # pkgs/cronet_http/android/build.gradle.
+          # api-level/minSdkVersion should be help in sync in:
+          # - .github/workflows/cronet.yml
+          # - pkgs/cronet_http/android/build.gradle
+          # - pkgs/cronet_http/example/android/app/build.gradle
           api-level: 24
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           arch: x86_64

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           # This should match the minSdkVersion in
           # pkgs/cronet_http/android/build.gradle.
-          api-level: 22
+          api-level: 24
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           arch: x86_64
           profile: pixel

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -64,6 +64,5 @@ jobs:
           # - pkgs/cronet_http/example/android/app/build.gradle
           api-level: 24
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
-          arch: x86_64
           profile: pixel
           script: cd 'pkgs/${{ matrix.package }}/example' && flutter test --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -62,7 +62,7 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: 24
+          api-level: 28
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           profile: pixel
           script: cd 'pkgs/${{ matrix.package }}/example' && flutter test --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           # This should match the minSdkVersion in
           # pkgs/cronet_http/android/build.gradle.
-          api-level: 19
+          api-level: 21
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           arch: x86_64
           profile: pixel

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           # This should match the minSdkVersion in
           # pkgs/cronet_http/android/build.gradle.
-          api-level: 21
+          api-level: 22
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           arch: x86_64
           profile: pixel

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -58,6 +58,8 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         if: always() && steps.install.outcome == 'success'
         with:
+          # This should match the minSdkVersion in
+          # pkgs/cronet_http/android/build.gradle.
           api-level: 19
           target: ${{ matrix.package == 'cronet_http_embedded' && 'google_apis' || 'playstore' }}
           arch: x86_64

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -46,6 +46,7 @@ android {
     }
 
     defaultConfig {
+        // This should match the version tested in .github/workflows/cronet.yml
         minSdkVersion 19
     }
 

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         // This should match the version tested in .github/workflows/cronet.yml
-        minSdkVersion 22
+        minSdkVersion 24
     }
 
     defaultConfig {

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         // This should match the version tested in .github/workflows/cronet.yml
-        minSdkVersion 19
+        minSdkVersion 21
     }
 
     defaultConfig {

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -46,7 +46,10 @@ android {
     }
 
     defaultConfig {
-        // This should match the version tested in .github/workflows/cronet.yml
+        // api-level/minSdkVersion should be help in sync in:
+        // - .github/workflows/cronet.yml
+        // - pkgs/cronet_http/android/build.gradle
+        // - pkgs/cronet_http/example/android/app/build.gradle
         minSdkVersion 24
     }
 

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -50,7 +50,7 @@ android {
         // - .github/workflows/cronet.yml
         // - pkgs/cronet_http/android/build.gradle
         // - pkgs/cronet_http/example/android/app/build.gradle
-        minSdkVersion 24
+        minSdkVersion 28
     }
 
     defaultConfig {

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -47,7 +47,7 @@ android {
 
     defaultConfig {
         // This should match the version tested in .github/workflows/cronet.yml
-        minSdkVersion 21
+        minSdkVersion 22
     }
 
     defaultConfig {

--- a/pkgs/cronet_http/example/android/app/build.gradle
+++ b/pkgs/cronet_http/example/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
         // - .github/workflows/cronet.yml
         // - pkgs/cronet_http/android/build.gradle
         // - pkgs/cronet_http/example/android/app/build.gradle
-        minSdkVersion 24
+        minSdkVersion 28
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pkgs/cronet_http/example/android/app/build.gradle
+++ b/pkgs/cronet_http/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
         applicationId "io.flutter.cronet_http_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 22
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pkgs/cronet_http/example/android/app/build.gradle
+++ b/pkgs/cronet_http/example/android/app/build.gradle
@@ -46,6 +46,10 @@ android {
         applicationId "io.flutter.cronet_http_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
+        // api-level/minSdkVersion should be help in sync in:
+        // - .github/workflows/cronet.yml
+        // - pkgs/cronet_http/android/build.gradle
+        // - pkgs/cronet_http/example/android/app/build.gradle
         minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/pkgs/cronet_http/example/android/app/build.gradle
+++ b/pkgs/cronet_http/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
         applicationId "io.flutter.cronet_http_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
-        minSdkVersion 21
+        minSdkVersion 22
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -13,6 +13,9 @@
 /// 1. Modifying the Gradle build file to reference the embedded Cronet.
 /// 2. Modifying the *name* and *description* in `pubspec.yaml`.
 /// 3. Replacing `README.md` with `README_EMBEDDED.md`.
+/// 4. Change the name of `cronet_http.dart` to `cronet_http_embedded.dart`.
+/// 5. Update all the imports from `package:cronet_http/cronet_http.dart` to
+///    `package:cronet_http_embedded/cronet_http_embedded.dart`
 ///
 /// After running this script, `flutter pub publish`
 /// can be run to update package:cronet_http_embedded.
@@ -40,8 +43,6 @@ final _cronetVersionUri = Uri.https(
   'android/maven2/org/chromium/net/group-index.xml',
 );
 
-/// Runs `prepare_for_embedded.dart publish` for publishing,
-/// or only the Android dependency will be modified.
 void main(List<String> args) async {
   if (Directory.current.path.endsWith('tool')) {
     _packageDirectory = Directory.current.parent;
@@ -53,8 +54,8 @@ void main(List<String> args) async {
   updateCronetDependency(latestVersion);
   updatePubSpec();
   updateReadme();
+  updateLibraryName();
   updateImports();
-  updateEntryPoint();
 }
 
 Future<String> _getLatestCronetVersion() async {
@@ -129,7 +130,7 @@ void updateImports() {
   }
 }
 
-void updateEntryPoint() {
+void updateLibraryName() {
   print('Renaming cronet_http.dart to cronet_http_embedded.dart');
   File(
     '${_packageDirectory.path}/lib/cronet_http.dart',


### PR DESCRIPTION
- Ensure that SDK version requirements are consistent (and document to change them in sync)
- Ensure that embedded cronet does not use Google Play Services
- Minor documentation updates

My intent is to publish `package:cronet_http_embedded` 0.4.2 from this source. I'll then land https://github.com/dart-lang/http/pull/1087 and publish `package:cronet_http`.

So, at that point, `package:cronet_http` and `package:cronet_http_embedded` will be functionally identical but `package:cronet_http_embedded` will still have a <1.0 version number.

In the new year we can sort out what publisher to use for `package:cronet_http_embedded`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
