### PR TITLE
Remove the "play-services-cronet" dependency in the example app when building `package:cronet_http_embedded`

### DIFF
--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         package: ['cronet_http', 'cronet_http_embedded']

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         package: ['cronet_http', 'cronet_http_embedded']

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -42,6 +42,8 @@ final _cronetVersionUri = Uri.https(
   'dl.google.com',
   'android/maven2/org/chromium/net/group-index.xml',
 );
+// Finds the Google Play Services Cronet dependency line. For example:
+// '    implementation "com.google.android.gms:play-services-cronet:18.0.1"'
 final implementationRegExp = RegExp(
   '^\\s*implementation [\'"]'
   '$_gmsDependencyName'

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -96,7 +96,8 @@ void updateBuildGradle(String latestVersion) {
 
 /// Remove the cronet reference from ./example/android/app/build.gradle.
 void updateExampleBuildGradle() {
-  final buildGradle = File('${_packageDirectory.path}/android/build.gradle');
+  final buildGradle =
+      File('${_packageDirectory.path}/example/android/app/build.gradle');
   final gradleContent = buildGradle.readAsStringSync();
 
   print('Updating ${buildGradle.path}: removing cronet reference');

--- a/pkgs/cronet_http/tool/prepare_for_embedded.dart
+++ b/pkgs/cronet_http/tool/prepare_for_embedded.dart
@@ -103,7 +103,7 @@ void updateExampleBuildGradle() {
   print('Updating ${buildGradle.path}: removing cronet reference');
   final newGradleContent = gradleContent.replaceAll(
     implementationRegExp,
-    '',
+    '    // NOTE: removed in package:cronet_http_embedded',
   );
   buildGradle.writeAsStringSync(newGradleContent);
 }


### PR DESCRIPTION
- Modify the `tool/prepare_for_embedded.dart` script to remove the dependency on "com.google.android.gms:play-services-cronet" from "example/android/app/build.gradle". The dependency is only there to allow `package:jnigen` to see Cronet classes when run against the example application. If this dependency is not removed then the tests in "example/integration_tests" will fail because the symbols defined by "com.google.android.gms:play-services-cronet" will clash with those defined by "org.chromium.net:cronet-embedded".
- Fixes https://github.com/dart-lang/http/issues/1102

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
