### PR TITLE
Move `headersSplitValues` into `BaseClient`

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-wip
+
+* `BaseResponse` can be constructed `headers` as a
+  `Map<String, List<String>>`.
+* Move `headersSplitValues` to `BaseResponse`.
+
 ## 1.2.0-wip
 
 * Add `MockClient.pngResponse`, which makes it easier to fake image responses.

--- a/pkgs/http/lib/http.dart
+++ b/pkgs/http/lib/http.dart
@@ -16,7 +16,7 @@ import 'src/streamed_request.dart';
 
 export 'src/base_client.dart';
 export 'src/base_request.dart';
-export 'src/base_response.dart' show BaseResponse, HeadersWithSplitValues;
+export 'src/base_response.dart' show BaseResponse;
 export 'src/byte_stream.dart';
 export 'src/client.dart' hide zoneClient;
 export 'src/exception.dart';

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -108,12 +108,9 @@ class IOClient extends BaseClient {
 
       var response = await stream.pipe(ioRequest) as HttpClientResponse;
 
-      var headers = <String, String>{};
+      var headers = <String, List<String>>{};
       response.headers.forEach((key, values) {
-        // TODO: Remove trimRight() when
-        // https://github.com/dart-lang/sdk/issues/53005 is resolved and the
-        // package:http SDK constraint requires that version or later.
-        headers[key] = values.map((value) => value.trimRight()).join(',');
+        headers[key] = values;
       });
 
       return IOStreamedResponse(

--- a/pkgs/http/lib/src/response.dart
+++ b/pkgs/http/lib/src/response.dart
@@ -30,7 +30,7 @@ class Response extends BaseResponse {
   /// Creates a new HTTP response with a string body.
   Response(String body, int statusCode,
       {BaseRequest? request,
-      Map<String, String> headers = const {},
+      Object headers = const <String, List<String>>{},
       bool isRedirect = false,
       bool persistentConnection = true,
       String? reasonPhrase})
@@ -68,14 +68,19 @@ class Response extends BaseResponse {
 ///
 /// Defaults to [latin1] if the headers don't specify a charset or if that
 /// charset is unknown.
-Encoding _encodingForHeaders(Map<String, String> headers) =>
+Encoding _encodingForHeaders(Object headers) =>
     encodingForCharset(_contentTypeForHeaders(headers).parameters['charset']);
 
 /// Returns the [MediaType] object for the given headers's content-type.
 ///
 /// Defaults to `application/octet-stream`.
-MediaType _contentTypeForHeaders(Map<String, String> headers) {
-  var contentType = headers['content-type'];
+MediaType _contentTypeForHeaders(Object headers) {
+  final contentType = switch (headers) {
+    Map<String, String> commaHeaders => commaHeaders['content-type'],
+    Map<String, List<String>> listHeaders => listHeaders['content-type']?[0],
+    _ => throw StateError('unexpected header type: ${headers.runtimeType}')
+  };
+
   if (contentType != null) return MediaType.parse(contentType);
   return MediaType('application', 'octet-stream');
 }

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 1.2.0-wip
+version: 2.0.0-wip
 description: A composable, multi-platform, Future-based API for HTTP requests.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http
 

--- a/pkgs/http/test/response_test.dart
+++ b/pkgs/http/test/response_test.dart
@@ -22,9 +22,16 @@ void main() {
               [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33]));
     });
 
-    test('respects the inferred encoding', () {
+    test('respects the inferred encoding, comma-separated values headers', () {
       var response = http.Response('föøbãr', 200,
           headers: {'content-type': 'text/plain; charset=iso-8859-1'});
+      expect(response.bodyBytes, equals([102, 246, 248, 98, 227, 114]));
+    });
+
+    test('respects the inferred encoding, list values headers', () {
+      var response = http.Response('föøbãr', 200, headers: {
+        'content-type': ['text/plain; charset=iso-8859-1']
+      });
       expect(response.bodyBytes, equals([102, 246, 248, 98, 227, 114]));
     });
   });
@@ -40,9 +47,17 @@ void main() {
       expect(response.bodyBytes, equals([104, 101, 108, 108, 111]));
     });
 
-    test('respects the inferred encoding', () {
+    test('respects the inferred encoding, comma-separated values headers', () {
       var response = http.Response.bytes([102, 246, 248, 98, 227, 114], 200,
           headers: {'content-type': 'text/plain; charset=iso-8859-1'});
+      expect(response.body, equals('föøbãr'));
+    });
+
+    test('respects the inferred encoding, list values headers', () {
+      var response = http.Response.bytes([102, 246, 248, 98, 227, 114], 200,
+          headers: {
+            'content-type': ['text/plain; charset=iso-8859-1']
+          });
       expect(response.body, equals('föøbãr'));
     });
   });
@@ -71,9 +86,32 @@ void main() {
     });
   });
 
-  group('.headersSplitValues', () {
+  group('.headers from values list', () {
     test('no headers', () async {
-      var response = http.Response('Hello, world!', 200);
+      var response = http.Response('Hello, world!', 200,
+          headers: const <String, List<String>>{});
+      expect(response.headers, const <String, String>{});
+    });
+
+    test('one header', () async {
+      var response = http.Response('Hello, world!', 200, headers: const {
+        'fruit': ['apple']
+      });
+      expect(response.headers, const {'fruit': 'apple'});
+    });
+
+    test('two headers', () async {
+      var response = http.Response('Hello, world!', 200, headers: {
+        'fruit': ['apple', 'banana']
+      });
+      expect(response.headers, const {'fruit': 'apple, banana'});
+    });
+  });
+
+  group('.headersSplitValues from comma-separated values', () {
+    test('no headers', () async {
+      var response = http.Response('Hello, world!', 200,
+          headers: const <String, String>{});
       expect(response.headersSplitValues, const <String, List<String>>{});
     });
 

--- a/pkgs/http_client_conformance_tests/lib/src/response_cookies_test.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/response_cookies_test.dart
@@ -32,6 +32,7 @@ void testResponseCookies(Client client,
       final response = await client.get(Uri.http(host, ''));
 
       expect(response.headers['set-cookie'], 'SID=1231AB3');
+      expect(response.headersSplitValues['set-cookie'], ['SID=1231AB3']);
     },
         skip: canReceiveSetCookieHeaders
             ? false
@@ -51,6 +52,8 @@ void testResponseCookies(Client client,
           matches(r'SID=1231AB3'
               r'[ \t]*,[ \t]*'
               r'lang=en_US'));
+      expect(response.headersSplitValues['set-cookie'],
+          ['SID=1231AB3', 'lang=en_US']);
     },
         skip: canReceiveSetCookieHeaders
             ? false
@@ -63,6 +66,8 @@ void testResponseCookies(Client client,
 
       expect(response.headers['set-cookie'],
           'id=a3fWa; Expires=Wed, 10 Jan 2024 07:28:00 GMT');
+      expect(response.headersSplitValues['set-cookie'],
+          ['id=a3fWa; Expires=Wed, 10 Jan 2024 07:28:00 GMT']);
     },
         skip: canReceiveSetCookieHeaders
             ? false
@@ -84,6 +89,10 @@ void testResponseCookies(Client client,
           matches(r'id=a3fWa; Expires=Wed, 10 Jan 2024 07:28:00 GMT'
               r'[ \t]*,[ \t]*'
               r'id=2fasd; Expires=Wed, 21 Oct 2025 07:28:00 GMT'));
+      expect(response.headersSplitValues['set-cookie'], [
+        'id=a3fWa; Expires=Wed, 10 Jan 2024 07:28:00 GMT',
+        'id=2fasd; Expires=Wed, 21 Oct 2025 07:28:00 GMT'
+      ]);
     },
         skip: canReceiveSetCookieHeaders
             ? false


### PR DESCRIPTION
Move `headersSplitValues` into `BaseClient` and allow the `headers` parameter in the `BaseClient` constructor to be `Map<String, String>` or `Map<String, List<String>>`.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
