### PR TITLE
Make it possible for `CronetClient` to own the lifetime of an existing `CronetEngine`

### DIFF
--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+* Make it possible to construct `CronetClient` with custom a `CronetEngine`
+  while still allowing `CronetClient` to close the `CronetEngine`.
+
 ## 1.1.0
 
 * Use `package:http_image_provider` in the example application.

--- a/pkgs/cronet_http/README.md
+++ b/pkgs/cronet_http/README.md
@@ -43,7 +43,7 @@ void main() async {
         cacheMode: CacheMode.memory,
         cacheMaxSize: 2 * 1024 * 1024,
         userAgent: 'Book Agent');
-    httpClient = CronetClient.fromCronetEngine(engine);
+    httpClient = CronetClient.fromCronetEngine(engine, isOwned: true);
   } else {
     httpClient = IOClient(HttpClient()..userAgent = 'Book Agent');
   }
@@ -52,6 +52,7 @@ void main() async {
       'www.googleapis.com',
       '/books/v1/volumes',
       {'q': 'HTTP', 'maxResults': '40', 'printType': 'books'}));
+  httpClient.close();
 }
 ```
 

--- a/pkgs/cronet_http/example/integration_test/cronet_configuration_test.dart
+++ b/pkgs/cronet_http/example/integration_test/cronet_configuration_test.dart
@@ -138,12 +138,12 @@ void testEngineClose() {
 
     test('engine owned close', () {
       final engine = CronetEngine.build();
-      CronetClient.fromCronetEngine(engine, isOwned: true).close();
+      CronetClient.fromCronetEngine(engine, closeEngine: true).close();
     });
 
     test('engine not owned close', () {
       final engine = CronetEngine.build();
-      CronetClient.fromCronetEngine(engine, isOwned: false).close();
+      CronetClient.fromCronetEngine(engine, closeEngine: false).close();
       engine.close();
     });
   });

--- a/pkgs/cronet_http/example/lib/main.dart
+++ b/pkgs/cronet_http/example/lib/main.dart
@@ -21,7 +21,7 @@ void main() {
         cacheMode: CacheMode.memory,
         cacheMaxSize: 2 * 1024 * 1024,
         userAgent: 'Book Agent');
-    httpClient = CronetClient.fromCronetEngine(engine, isOwned: true);
+    httpClient = CronetClient.fromCronetEngine(engine, closeEngine: true);
   } else {
     httpClient = IOClient(HttpClient()..userAgent = 'Book Agent');
   }

--- a/pkgs/cronet_http/example/lib/main.dart
+++ b/pkgs/cronet_http/example/lib/main.dart
@@ -21,7 +21,7 @@ void main() {
         cacheMode: CacheMode.memory,
         cacheMaxSize: 2 * 1024 * 1024,
         userAgent: 'Book Agent');
-    httpClient = CronetClient.fromCronetEngine(engine);
+    httpClient = CronetClient.fromCronetEngine(engine, isOwned: true);
   } else {
     httpClient = IOClient(HttpClient()..userAgent = 'Book Agent');
   }

--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -49,6 +49,7 @@ enum CacheMode {
 /// An environment that can be used to make HTTP requests.
 class CronetEngine {
   late final jb.CronetEngine _engine;
+  bool _isClosed = false;
 
   CronetEngine._(this._engine);
 
@@ -140,7 +141,11 @@ class CronetEngine {
   }
 
   void close() {
-    _engine.shutdown();
+    if (!_isClosed) {
+      _engine.shutdown();
+      _engine.release();
+    }
+    _isClosed = true;
   }
 }
 

--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -282,9 +282,9 @@ class CronetClient extends BaseClient {
   bool _isClosed = false;
 
   /// Indicates that [CronetClient] is responsible for closing [_engine].
-  final bool _ownedEngine;
+  final bool _closeEngine;
 
-  CronetClient._(this._engine, this._ownedEngine) {
+  CronetClient._(this._engine, this._closeEngine) {
     Jni.initDLApi();
   }
 
@@ -293,12 +293,12 @@ class CronetClient extends BaseClient {
 
   /// A [CronetClient] configured with a [CronetEngine].
   ///
-  /// If [isOwned] is `true`, then [engine] will be closed when [close] is
-  /// called. This can simplify lifetime management if [engine] is only used
-  /// in one [CronetClient].
+  /// If [closeEngine] is `true`, then [engine] will be closed when [close] is
+  /// called on this [CronetClient]. This can simplify lifetime management if
+  /// [engine] is only used in one [CronetClient].
   factory CronetClient.fromCronetEngine(CronetEngine engine,
-          {bool isOwned = false}) =>
-      CronetClient._(engine, isOwned);
+          {bool closeEngine = false}) =>
+      CronetClient._(engine, closeEngine);
 
   /// A [CronetClient] configured with a [Future] containing a [CronetEngine].
   ///
@@ -318,7 +318,7 @@ class CronetClient extends BaseClient {
   /// ```
   @override
   void close() {
-    if (!_isClosed && _ownedEngine) {
+    if (!_isClosed && _closeEngine) {
       _engine?.close();
     }
     _isClosed = true;

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cronet_http
-version: 1.1.0
+version: 1.1.1
 description: >-
   An Android Flutter plugin that provides access to the Cronet HTTP client.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http


### PR DESCRIPTION
...also releases the Java `CronetEngine` when the Dart one is closed.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
