### PR TITLE
API adjustments based on cupertino_http usage experience

### DIFF
--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async' show StreamController, StreamSink;
+import 'dart:async' show StreamController, StreamSink, unawaited;
 import 'dart:developer' show Service, addHttpClientProfilingData;
 import 'dart:io' show HttpClient, HttpClientResponseCompressionState;
 import 'dart:isolate' show Isolate;
@@ -246,7 +246,7 @@ final class HttpProfileRequestData {
   void close([DateTime? endTime]) {
     _checkAndUpdate();
     _isClosed = true;
-    bodySink.close();
+    unawaited(bodySink.close());
     _data['requestEndTimestamp'] =
         (endTime ?? DateTime.now()).microsecondsSinceEpoch;
   }
@@ -263,7 +263,7 @@ final class HttpProfileRequestData {
   void closeWithError(String value, [DateTime? endTime]) {
     _checkAndUpdate();
     _isClosed = true;
-    bodySink.close();
+    unawaited(bodySink.close());
     _requestData['error'] = value;
     _data['requestEndTimestamp'] =
         (endTime ?? DateTime.now()).microsecondsSinceEpoch;
@@ -424,7 +424,7 @@ final class HttpProfileResponseData {
   void close([DateTime? endTime]) {
     _checkAndUpdate();
     _isClosed = true;
-    bodySink.close();
+    unawaited(bodySink.close());
     _data['endTime'] = (endTime ?? DateTime.now()).microsecondsSinceEpoch;
   }
 
@@ -440,7 +440,7 @@ final class HttpProfileResponseData {
   void closeWithError(String value, [DateTime? endTime]) {
     _checkAndUpdate();
     _isClosed = true;
-    bodySink.close();
+    unawaited(bodySink.close());
     _data['error'] = value;
     _data['endTime'] = (endTime ?? DateTime.now()).microsecondsSinceEpoch;
   }

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -185,7 +185,7 @@ final class HttpProfileRequestData {
   }
 
   /// The request headers where duplicate headers are represented using a
-  /// comma-seperated list of values.
+  /// comma-separated list of values.
   ///
   /// For example:
   ///

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -184,7 +184,7 @@ final class HttpProfileRequestData {
     _requestData['headers'] = {...value};
   }
 
-  /// The request headers where duplicate headers are represented using
+  /// The request headers where duplicate headers are represented using a
   /// comma-seperated list of values.
   ///
   /// For example:

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -283,7 +283,7 @@ final class HttpProfileResponseData {
     (_data['redirects'] as List<Map<String, dynamic>>).add(redirect._toJson());
   }
 
-  /// The body of the request.
+  /// The body of the response.
   StreamSink<List<int>> get bodySink => _body.sink;
 
   /// Information about the networking connection used in the HTTP response.

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -325,7 +325,7 @@ final class HttpProfileResponseData {
     _data['headers'] = {...value};
   }
 
-  /// The response headers where duplicate headers are represented using
+  /// The response headers where duplicate headers are represented using a
   /// comma-seperated list of values.
   ///
   /// For example:

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -12,7 +12,7 @@ import 'dart:isolate' show Isolate;
 const _tokenChars = r"!#$%&'*+\-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`"
     'abcdefghijklmnopqrstuvwxyz|~';
 
-/// Splits comma-seperated header values.
+/// Splits comma-separated header values.
 var _headerSplitter = RegExp(r'[ \t]*,[ \t]*');
 
 /// Splits comma-seperated "Set-Cookie" header values.

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -36,7 +36,7 @@ var _headerSplitter = RegExp(r'[ \t]*,[ \t]*');
 /// See https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1
 var _setCookieSplitter = RegExp(r'[ \t]*,[ \t]*(?=[' + _tokenChars + r']+=)');
 
-/// Splits comma-seperated header values into a [List].
+/// Splits comma-separated header values into a [List].
 ///
 /// Copied from `package:http`.
 Map<String, List<String>> _splitHeaderValues(Map<String, String> headers) {

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -15,7 +15,7 @@ const _tokenChars = r"!#$%&'*+\-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`"
 /// Splits comma-separated header values.
 var _headerSplitter = RegExp(r'[ \t]*,[ \t]*');
 
-/// Splits comma-seperated "Set-Cookie" header values.
+/// Splits comma-separated "Set-Cookie" header values.
 ///
 /// Set-Cookie strings can contain commas. In particular, the following
 /// productions defined in RFC-6265, section 4.1.1:

--- a/pkgs/http_profile/lib/http_profile.dart
+++ b/pkgs/http_profile/lib/http_profile.dart
@@ -326,7 +326,7 @@ final class HttpProfileResponseData {
   }
 
   /// The response headers where duplicate headers are represented using a
-  /// comma-seperated list of values.
+  /// comma-separated list of values.
   ///
   /// For example:
   ///

--- a/pkgs/http_profile/test/close_test.dart
+++ b/pkgs/http_profile/test/close_test.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:developer' show getHttpClientProfilingData;
+
+import 'package:http_profile/http_profile.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late HttpClientRequestProfile profile;
+  late Map<String, dynamic> backingMap;
+
+  setUp(() {
+    HttpClientRequestProfile.profilingEnabled = true;
+
+    profile = HttpClientRequestProfile.profile(
+      requestStartTime: DateTime.parse('2024-03-21'),
+      requestMethod: 'GET',
+      requestUri: 'https://www.example.com',
+    )!;
+
+    final profileBackingMaps = getHttpClientProfilingData();
+    expect(profileBackingMaps.length, isPositive);
+    backingMap = profileBackingMaps.lastOrNull!;
+  });
+
+  group('requestData.close', () {
+    test('no arguments', () async {
+      expect(backingMap['requestEndTimestamp'], isNull);
+      profile.requestData.close();
+
+      expect(
+        backingMap['requestEndTimestamp'],
+        closeTo(DateTime.now().microsecondsSinceEpoch,
+            Duration.microsecondsPerSecond),
+      );
+    });
+
+    test('with time', () async {
+      expect(backingMap['requestEndTimestamp'], isNull);
+      profile.requestData.close(DateTime.parse('2024-03-23'));
+
+      expect(
+        backingMap['requestEndTimestamp'],
+        DateTime.parse('2024-03-23').microsecondsSinceEpoch,
+      );
+    });
+
+    test('then write body', () async {
+      profile.requestData.close();
+
+      expect(
+        () => profile.requestData.bodySink.add([1, 2, 3]),
+        throwsStateError,
+      );
+    });
+
+    test('then mutate', () async {
+      profile.requestData.close();
+
+      expect(
+        () => profile.requestData.contentLength = 5,
+        throwsStateError,
+      );
+    });
+  });
+
+  group('responseData.close', () {
+    late Map<String, dynamic> responseData;
+
+    setUp(() {
+      responseData = backingMap['responseData'] as Map<String, dynamic>;
+    });
+
+    test('no arguments', () async {
+      expect(responseData['endTime'], isNull);
+      profile.responseData.close();
+
+      expect(
+        responseData['endTime'],
+        closeTo(DateTime.now().microsecondsSinceEpoch,
+            Duration.microsecondsPerSecond),
+      );
+    });
+
+    test('with time', () async {
+      expect(responseData['endTime'], isNull);
+      profile.responseData.close(DateTime.parse('2024-03-23'));
+
+      expect(
+        responseData['endTime'],
+        DateTime.parse('2024-03-23').microsecondsSinceEpoch,
+      );
+    });
+
+    test('then write body', () async {
+      profile.responseData.close();
+
+      expect(
+        () => profile.responseData.bodySink.add([1, 2, 3]),
+        throwsStateError,
+      );
+    });
+
+    test('then mutate', () async {
+      profile.responseData.close();
+
+      expect(
+        () => profile.responseData.contentLength = 5,
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/pkgs/http_profile/test/profiling_enabled_test.dart
+++ b/pkgs/http_profile/test/profiling_enabled_test.dart
@@ -13,7 +13,7 @@ void main() {
     expect(HttpClient.enableTimelineLogging, true);
     expect(
       HttpClientRequestProfile.profile(
-        requestStartTimestamp: DateTime.parse('2024-03-21'),
+        requestStartTime: DateTime.parse('2024-03-21'),
         requestMethod: 'GET',
         requestUri: 'https://www.example.com',
       ),
@@ -26,7 +26,7 @@ void main() {
     expect(HttpClient.enableTimelineLogging, false);
     expect(
       HttpClientRequestProfile.profile(
-        requestStartTimestamp: DateTime.parse('2024-03-21'),
+        requestStartTime: DateTime.parse('2024-03-21'),
         requestMethod: 'GET',
         requestUri: 'https://www.example.com',
       ),


### PR DESCRIPTION
- Remove support for cookies (because it is hard)
- Add the ability to set headers stored as a string-to-string mapping
- Add `close` methods to ...RequestData and ...ResponseData
- Allow some fields to be nullable

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
