### PR TITLE
Add `WebSocket.connect` as a cross-platform connection method

### DIFF
--- a/pkgs/web_socket/README.md
+++ b/pkgs/web_socket/README.md
@@ -7,12 +7,11 @@ implementations.
 ## Using
 
 ```dart
-import 'package:web_socket/io_web_socket.dart';
 import 'package:web_socket/web_socket.dart';
 
 void main() async {
   final socket =
-      await IOWebSocket.connect(Uri.parse('wss://ws.postman-echo.com/raw'));
+      await WebSocket.connect(Uri.parse('wss://ws.postman-echo.com/raw'));
 
   socket.events.listen((e) async {
     switch (e) {

--- a/pkgs/web_socket/example/web_socket_example.dart
+++ b/pkgs/web_socket/example/web_socket_example.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:web_socket/io_web_socket.dart';
 import 'package:web_socket/web_socket.dart';
 
 const requestId = 305;
@@ -11,7 +10,7 @@ void main() async {
   // Whitebit public WebSocket API documentation:
   // https://docs.whitebit.com/public/websocket/
   final socket =
-      await IOWebSocket.connect(Uri.parse('wss://api.whitebit.com/ws'));
+      await WebSocket.connect(Uri.parse('wss://api.whitebit.com/ws'));
 
   socket.events.listen((e) {
     switch (e) {

--- a/pkgs/web_socket/lib/src/browser_web_socket.dart
+++ b/pkgs/web_socket/lib/src/browser_web_socket.dart
@@ -20,9 +20,7 @@ class BrowserWebSocket implements WebSocket {
 
   static Future<BrowserWebSocket> connect(Uri url,
       {Iterable<String>? protocols}) async {
-    final webSocket = web.WebSocket(url.toString(),
-        protocols?.map((e) => e.toJS).toList().toJS ?? JSArray())
-      ..binaryType = 'arraybuffer';
+    final webSocket = web.WebSocket(url.toString())..binaryType = 'arraybuffer';
     final browserSocket = BrowserWebSocket._(webSocket);
     final webSocketConnected = Completer<BrowserWebSocket>();
 
@@ -128,9 +126,6 @@ class BrowserWebSocket implements WebSocket {
 
   @override
   Stream<WebSocketEvent> get events => _events.stream;
-
-  @override
-  String get protocol => _webSocket.protocol;
 }
 
 const connect = BrowserWebSocket.connect;

--- a/pkgs/web_socket/lib/src/browser_web_socket.dart
+++ b/pkgs/web_socket/lib/src/browser_web_socket.dart
@@ -18,8 +18,11 @@ class BrowserWebSocket implements WebSocket {
   final web.WebSocket _webSocket;
   final _events = StreamController<WebSocketEvent>();
 
-  static Future<BrowserWebSocket> connect(Uri url) async {
-    final webSocket = web.WebSocket(url.toString())..binaryType = 'arraybuffer';
+  static Future<BrowserWebSocket> connect(Uri url,
+      {Iterable<String>? protocols}) async {
+    final webSocket = web.WebSocket(url.toString(),
+        protocols?.map((e) => e.toJS).toList().toJS ?? JSArray())
+      ..binaryType = 'arraybuffer';
     final browserSocket = BrowserWebSocket._(webSocket);
     final webSocketConnected = Completer<BrowserWebSocket>();
 
@@ -125,4 +128,9 @@ class BrowserWebSocket implements WebSocket {
 
   @override
   Stream<WebSocketEvent> get events => _events.stream;
+
+  @override
+  String get protocol => _webSocket.protocol;
 }
+
+const connect = BrowserWebSocket.connect;

--- a/pkgs/web_socket/lib/src/connect_stub.dart
+++ b/pkgs/web_socket/lib/src/connect_stub.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import '../web_socket.dart';
 
 Future<WebSocket> connect(Uri url, {Iterable<String>? protocols}) {

--- a/pkgs/web_socket/lib/src/connect_stub.dart
+++ b/pkgs/web_socket/lib/src/connect_stub.dart
@@ -1,0 +1,5 @@
+import '../web_socket.dart';
+
+Future<WebSocket> connect(Uri url, {Iterable<String>? protocols}) {
+  throw UnsupportedError('Cannot connect without dart:js_interop or dart:io.');
+}

--- a/pkgs/web_socket/lib/src/io_web_socket.dart
+++ b/pkgs/web_socket/lib/src/io_web_socket.dart
@@ -19,8 +19,7 @@ class IOWebSocket implements WebSocket {
   static Future<IOWebSocket> connect(Uri url,
       {Iterable<String>? protocols}) async {
     try {
-      final webSocket =
-          await io.WebSocket.connect(url.toString(), protocols: protocols);
+      final webSocket = await io.WebSocket.connect(url.toString());
       return IOWebSocket._(webSocket);
     } on io.WebSocketException catch (e) {
       throw WebSocketException(e.message);
@@ -91,9 +90,6 @@ class IOWebSocket implements WebSocket {
 
   @override
   Stream<WebSocketEvent> get events => _events.stream;
-
-  @override
-  String get protocol => _webSocket.protocol ?? '';
 }
 
 const connect = IOWebSocket.connect;

--- a/pkgs/web_socket/lib/src/io_web_socket.dart
+++ b/pkgs/web_socket/lib/src/io_web_socket.dart
@@ -16,9 +16,11 @@ class IOWebSocket implements WebSocket {
   final io.WebSocket _webSocket;
   final _events = StreamController<WebSocketEvent>();
 
-  static Future<IOWebSocket> connect(Uri uri) async {
+  static Future<IOWebSocket> connect(Uri url,
+      {Iterable<String>? protocols}) async {
     try {
-      final webSocket = await io.WebSocket.connect(uri.toString());
+      final webSocket =
+          await io.WebSocket.connect(url.toString(), protocols: protocols);
       return IOWebSocket._(webSocket);
     } on io.WebSocketException catch (e) {
       throw WebSocketException(e.message);
@@ -89,4 +91,9 @@ class IOWebSocket implements WebSocket {
 
   @override
   Stream<WebSocketEvent> get events => _events.stream;
+
+  @override
+  String get protocol => _webSocket.protocol ?? '';
 }
+
+const connect = IOWebSocket.connect;

--- a/pkgs/web_socket/lib/src/web_socket.dart
+++ b/pkgs/web_socket/lib/src/web_socket.dart
@@ -91,9 +91,6 @@ class WebSocketConnectionClosed extends WebSocketException {
   WebSocketConnectionClosed([super.message = 'Connection Closed']);
 }
 
-typedef WebSocketConnector = Future<WebSocket> Function(Uri url,
-    {Iterable<String>? protocols});
-
 /// The interface for WebSocket connections.
 ///
 /// ```dart

--- a/pkgs/web_socket/lib/src/web_socket.dart
+++ b/pkgs/web_socket/lib/src/web_socket.dart
@@ -4,6 +4,10 @@
 
 import 'dart:typed_data';
 
+import 'connect_stub.dart'
+    if (dart.library.js_interop) 'browser_web_socket.dart'
+    if (dart.library.io) 'io_web_socket.dart' as connector;
+
 /// An event received from the peer through the [WebSocket].
 sealed class WebSocketEvent {}
 
@@ -90,12 +94,11 @@ class WebSocketConnectionClosed extends WebSocketException {
 /// The interface for WebSocket connections.
 ///
 /// ```dart
-/// import 'package:web_socket/io_web_socket.dart';
 /// import 'package:web_socket/src/web_socket.dart';
 ///
 /// void main() async {
 ///   final socket =
-///       await IOWebSocket.connect(Uri.parse('wss://ws.postman-echo.com/raw'));
+///       await WebSocket.connect(Uri.parse('wss://ws.postman-echo.com/raw'));
 ///
 ///   socket.events.listen((e) async {
 ///     switch (e) {
@@ -112,6 +115,9 @@ class WebSocketConnectionClosed extends WebSocketException {
 ///   socket.sendText('Hello Dart WebSockets! 🎉');
 /// }
 abstract interface class WebSocket {
+  static Future<WebSocket> connect(Uri url, {Iterable<String>? protocols}) =>
+      connector.connect(url, protocols: protocols);
+
   /// Sends text data to the connected peer.
   ///
   /// Throws [WebSocketConnectionClosed] if the [WebSocket] is
@@ -163,4 +169,6 @@ abstract interface class WebSocket {
   ///
   /// Errors will never appear in this [Stream].
   Stream<WebSocketEvent> get events;
+
+  String get protocol;
 }

--- a/pkgs/web_socket/lib/src/web_socket.dart
+++ b/pkgs/web_socket/lib/src/web_socket.dart
@@ -91,6 +91,9 @@ class WebSocketConnectionClosed extends WebSocketException {
   WebSocketConnectionClosed([super.message = 'Connection Closed']);
 }
 
+typedef WebSocketConnector = Future<WebSocket> Function(Uri url,
+    {Iterable<String>? protocols});
+
 /// The interface for WebSocket connections.
 ///
 /// ```dart
@@ -169,6 +172,4 @@ abstract interface class WebSocket {
   ///
   /// Errors will never appear in this [Stream].
   Stream<WebSocketEvent> get events;
-
-  String get protocol;
 }

--- a/pkgs/web_socket/test/io_web_socket_conformance_test.dart
+++ b/pkgs/web_socket/test/io_web_socket_conformance_test.dart
@@ -10,5 +10,5 @@ import 'package:web_socket/io_web_socket.dart';
 import 'package:web_socket_conformance_tests/web_socket_conformance_tests.dart';
 
 void main() {
-  testAll((uri, {protocols}) => IOWebSocket.connect(uri));
+  testAll(IOWebSocket.connect);
 }

--- a/pkgs/web_socket/test/websocket_test.dart
+++ b/pkgs/web_socket/test/websocket_test.dart
@@ -2,13 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@TestOn('browser')
-library;
-
-import 'package:test/test.dart';
-import 'package:web_socket/browser_web_socket.dart';
+import 'package:web_socket/web_socket.dart';
 import 'package:web_socket_conformance_tests/web_socket_conformance_tests.dart';
 
 void main() {
-  testAll(BrowserWebSocket.connect);
+  testAll(WebSocket.connect);
 }


### PR DESCRIPTION
- I'll implement the protocol-setting functionality in a follow-up PR.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
