### PR TITLE
[package:http_profile] Store request and response bodies in the backing map as lists instead of as streams

### DIFF
--- a/pkgs/http_profile/lib/src/http_client_request_profile.dart
+++ b/pkgs/http_profile/lib/src/http_client_request_profile.dart
@@ -76,10 +76,15 @@ final class HttpClientRequestProfile {
     _data['requestData'] = <String, dynamic>{};
     requestData = HttpProfileRequestData._(_data, _updated);
     _data['responseData'] = <String, dynamic>{};
-    responseData = HttpProfileResponseData._(
-        _data['responseData'] as Map<String, dynamic>, _updated);
-    _data['_requestBodyStream'] = requestData._body.stream;
-    _data['_responseBodyStream'] = responseData._body.stream;
+    responseData = HttpProfileResponseData._(_data, _updated);
+    _data['requestBodyBytes'] = <int>[];
+    requestData._body.stream.listen(
+      (final bytes) => (_data['requestBodyBytes'] as List<int>).addAll(bytes),
+    );
+    _data['responseBodyBytes'] = <int>[];
+    responseData._body.stream.listen(
+      (final bytes) => (_data['responseBodyBytes'] as List<int>).addAll(bytes),
+    );
     // This entry is needed to support the updatedSince parameter of
     // ext.dart.io.getHttpProfile.
     _updated();

--- a/pkgs/http_profile/lib/src/http_profile.dart
+++ b/pkgs/http_profile/lib/src/http_profile.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection' show UnmodifiableListView;
 import 'dart:developer' show Service, addHttpClientProfilingData;
 import 'dart:io' show HttpClient, HttpClientResponseCompressionState;
 import 'dart:isolate' show Isolate;

--- a/pkgs/http_profile/lib/src/http_profile_request_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_request_data.dart
@@ -38,8 +38,12 @@ final class HttpProfileRequestData {
   Map<String, dynamic> get _requestData =>
       _data['requestData'] as Map<String, dynamic>;
 
-  /// The body of the request.
+  /// A sink that can be used to record the body of the request.
   StreamSink<List<int>> get bodySink => _body.sink;
+
+  /// The body of the request represented as an unmodifiable list of bytes.
+  List<int> get bodyBytes =>
+      UnmodifiableListView(_data['requestBodyBytes'] as List<int>);
 
   /// Information about the networking connection used in the HTTP request.
   ///
@@ -155,10 +159,10 @@ final class HttpProfileRequestData {
   ///
   /// [endTime] is the time when the request was fully sent. It defaults to the
   /// current time.
-  void close([DateTime? endTime]) {
+  Future<void> close([DateTime? endTime]) async {
     _checkAndUpdate();
     _isClosed = true;
-    unawaited(bodySink.close());
+    await bodySink.close();
     _data['requestEndTimestamp'] =
         (endTime ?? DateTime.now()).microsecondsSinceEpoch;
   }
@@ -172,10 +176,10 @@ final class HttpProfileRequestData {
   ///
   /// [endTime] is the time when the error occurred. It defaults to the current
   /// time.
-  void closeWithError(String value, [DateTime? endTime]) {
+  Future<void> closeWithError(String value, [DateTime? endTime]) async {
     _checkAndUpdate();
     _isClosed = true;
-    unawaited(bodySink.close());
+    await bodySink.close();
     _requestData['error'] = value;
     _data['requestEndTimestamp'] =
         (endTime ?? DateTime.now()).microsecondsSinceEpoch;

--- a/pkgs/http_profile/test/close_test.dart
+++ b/pkgs/http_profile/test/close_test.dart
@@ -28,7 +28,7 @@ void main() {
   group('requestData.close', () {
     test('no arguments', () async {
       expect(backingMap['requestEndTimestamp'], isNull);
-      profile.requestData.close();
+      await profile.requestData.close();
 
       expect(
         backingMap['requestEndTimestamp'],
@@ -39,7 +39,7 @@ void main() {
 
     test('with time', () async {
       expect(backingMap['requestEndTimestamp'], isNull);
-      profile.requestData.close(DateTime.parse('2024-03-23'));
+      await profile.requestData.close(DateTime.parse('2024-03-23'));
 
       expect(
         backingMap['requestEndTimestamp'],
@@ -48,7 +48,7 @@ void main() {
     });
 
     test('then write body', () async {
-      profile.requestData.close();
+      await profile.requestData.close();
 
       expect(
         () => profile.requestData.bodySink.add([1, 2, 3]),
@@ -57,7 +57,7 @@ void main() {
     });
 
     test('then mutate', () async {
-      profile.requestData.close();
+      await profile.requestData.close();
 
       expect(
         () => profile.requestData.contentLength = 5,
@@ -75,7 +75,7 @@ void main() {
 
     test('no arguments', () async {
       expect(responseData['endTime'], isNull);
-      profile.responseData.close();
+      await profile.responseData.close();
 
       expect(
         responseData['endTime'],
@@ -86,7 +86,7 @@ void main() {
 
     test('with time', () async {
       expect(responseData['endTime'], isNull);
-      profile.responseData.close(DateTime.parse('2024-03-23'));
+      await profile.responseData.close(DateTime.parse('2024-03-23'));
 
       expect(
         responseData['endTime'],
@@ -95,7 +95,7 @@ void main() {
     });
 
     test('then write body', () async {
-      profile.responseData.close();
+      await profile.responseData.close();
 
       expect(
         () => profile.responseData.bodySink.add([1, 2, 3]),
@@ -104,7 +104,7 @@ void main() {
     });
 
     test('then mutate', () async {
-      profile.responseData.close();
+      await profile.responseData.close();
 
       expect(
         () => profile.responseData.contentLength = 5,

--- a/pkgs/http_profile/test/http_profile_request_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_request_data_test.dart
@@ -41,7 +41,7 @@ void main() {
 
   test('populating HttpClientRequestProfile.requestEndTimestamp', () async {
     expect(backingMap['requestEndTimestamp'], isNull);
-    profile.requestData.close(DateTime.parse('2024-03-23'));
+    await profile.requestData.close(DateTime.parse('2024-03-23'));
 
     expect(
       backingMap['requestEndTimestamp'],
@@ -91,7 +91,7 @@ void main() {
     final requestData = backingMap['requestData'] as Map<String, dynamic>;
     expect(requestData['error'], isNull);
 
-    profile.requestData.closeWithError('failed');
+    await profile.requestData.closeWithError('failed');
 
     expect(requestData['error'], 'failed');
   });
@@ -184,5 +184,17 @@ void main() {
     expect(proxyDetails['username'], 'abc123');
     expect(proxyDetails['isDirect'], true);
     expect(proxyDetails['port'], 4321);
+  });
+
+  test('using HttpClientRequestProfile.requestData.bodySink', () async {
+    final requestBodyBytes = backingMap['requestBodyBytes'] as List<int>;
+    expect(requestBodyBytes, isEmpty);
+    expect(profile.requestData.bodyBytes, isEmpty);
+
+    profile.requestData.bodySink.add([1, 2, 3]);
+    await profile.requestData.close();
+
+    expect(requestBodyBytes, [1, 2, 3]);
+    expect(profile.requestData.bodyBytes, [1, 2, 3]);
   });
 }

--- a/pkgs/http_profile/test/http_profile_response_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_response_data_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:developer' show getHttpClientProfilingData;
 import 'dart:io';
 
@@ -187,7 +186,7 @@ void main() {
     final responseData = backingMap['responseData'] as Map<String, dynamic>;
     expect(responseData['endTime'], isNull);
 
-    profile.responseData.close(DateTime.parse('2024-03-23'));
+    await profile.responseData.close(DateTime.parse('2024-03-23'));
 
     expect(
       responseData['endTime'],
@@ -199,28 +198,20 @@ void main() {
     final responseData = backingMap['responseData'] as Map<String, dynamic>;
     expect(responseData['error'], isNull);
 
-    profile.responseData.closeWithError('failed');
+    await profile.responseData.closeWithError('failed');
 
     expect(responseData['error'], 'failed');
   });
 
-  test('using HttpClientRequestProfile.requestBodySink', () async {
-    final requestBodyStream =
-        backingMap['_requestBodyStream'] as Stream<List<int>>;
-
-    profile.requestData.bodySink.add([1, 2, 3]);
-    profile.requestData.close();
-
-    expect(await requestBodyStream.expand((i) => i).toList(), [1, 2, 3]);
-  });
-
-  test('using HttpClientRequestProfile.responseBodySink', () async {
-    final responseBodyStream =
-        backingMap['_responseBodyStream'] as Stream<List<int>>;
+  test('using HttpClientRequestProfile.responseData.bodySink', () async {
+    final responseBodyBytes = backingMap['responseBodyBytes'] as List<int>;
+    expect(responseBodyBytes, isEmpty);
+    expect(profile.responseData.bodyBytes, isEmpty);
 
     profile.responseData.bodySink.add([1, 2, 3]);
-    profile.responseData.close();
+    await profile.responseData.close();
 
-    expect(await responseBodyStream.expand((i) => i).toList(), [1, 2, 3]);
+    expect(responseBodyBytes, [1, 2, 3]);
+    expect(profile.responseData.bodyBytes, [1, 2, 3]);
   });
 }


### PR DESCRIPTION
This PR also adds getters that return the request and response bodies as lists of ints