### PR TITLE
[package:http_profile] Make connectionInfo a top-level field of HttpClientRequestProfile

### DIFF
--- a/pkgs/http_profile/lib/src/http_client_request_profile.dart
+++ b/pkgs/http_profile/lib/src/http_client_request_profile.dart
@@ -77,6 +77,50 @@ final class HttpClientRequestProfile {
         HttpProfileRequestEvent._fromJson,
       ));
 
+  /// Information about the networking connection used.
+  ///
+  /// This information is meant to be used for debugging.
+  ///
+  /// It can contain any arbitrary data as long as the values are of type
+  /// [String] or [int].
+  ///
+  /// This field can only be modified by assigning a Map to it. That is:
+  /// ```dart
+  /// // Valid
+  /// profile?.connectionInfo = {
+  ///   'localPort': 1285,
+  ///   'remotePort': 443,
+  ///   'connectionPoolId': '21x23',
+  /// };
+  ///
+  /// // Invalid
+  /// profile?.connectionInfo?['localPort'] = 1285;
+  /// ```
+  set connectionInfo(Map<String, dynamic /*String|int*/ >? value) {
+    _updated();
+    if (value == null) {
+      requestData._requestData.remove('connectionInfo');
+      responseData._responseData.remove('connectionInfo');
+    } else {
+      for (final v in value.values) {
+        if (!(v is String || v is int)) {
+          throw ArgumentError(
+            'The values in connectionInfo must be of type String or int.',
+          );
+        }
+      }
+      requestData._requestData['connectionInfo'] = {...value};
+      responseData._responseData['connectionInfo'] = {...value};
+    }
+  }
+
+  Map<String, dynamic /*String|int*/ >? get connectionInfo =>
+      requestData._data['connectionInfo'] == null
+          ? null
+          : UnmodifiableMapView(
+              requestData._data['connectionInfo'] as Map<String, dynamic>,
+            );
+
   /// Details about the request.
   late final HttpProfileRequestData requestData;
 

--- a/pkgs/http_profile/lib/src/http_profile_request_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_request_data.dart
@@ -61,48 +61,6 @@ final class HttpProfileRequestData {
   List<int> get bodyBytes =>
       UnmodifiableListView(_data['requestBodyBytes'] as List<int>);
 
-  /// Information about the networking connection used in the HTTP request.
-  ///
-  /// This information is meant to be used for debugging.
-  ///
-  /// It can contain any arbitrary data as long as the values are of type
-  /// [String] or [int].
-  ///
-  /// This field can only be modified by assigning a Map to it. That is:
-  /// ```dart
-  /// // Valid
-  /// profile?.requestData.connectionInfo = {
-  ///   'localPort': 1285,
-  ///   'remotePort': 443,
-  ///   'connectionPoolId': '21x23',
-  /// };
-  ///
-  /// // Invalid
-  /// profile?.requestData.connectionInfo?['localPort'] = 1285;
-  /// ```
-  set connectionInfo(Map<String, dynamic /*String|int*/ >? value) {
-    _checkAndUpdate();
-    if (value == null) {
-      _requestData.remove('connectionInfo');
-    } else {
-      for (final v in value.values) {
-        if (!(v is String || v is int)) {
-          throw ArgumentError(
-            'The values in connectionInfo must be of type String or int.',
-          );
-        }
-      }
-      _requestData['connectionInfo'] = {...value};
-    }
-  }
-
-  Map<String, dynamic /*String|int*/ >? get connectionInfo =>
-      _requestData['connectionInfo'] == null
-          ? null
-          : UnmodifiableMapView(
-              _requestData['connectionInfo'] as Map<String, dynamic>,
-            );
-
   /// The content length of the request, in bytes.
   set contentLength(int? value) {
     _checkAndUpdate();

--- a/pkgs/http_profile/lib/src/http_profile_response_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_response_data.dart
@@ -68,41 +68,6 @@ final class HttpProfileResponseData {
   List<int> get bodyBytes =>
       UnmodifiableListView(_data['responseBodyBytes'] as List<int>);
 
-  /// Information about the networking connection used in the HTTP response.
-  ///
-  /// This information is meant to be used for debugging.
-  ///
-  /// It can contain any arbitrary data as long as the values are of type
-  /// [String] or [int].
-  ///
-  /// This field can only be modified by assigning a Map to it. That is:
-  /// ```dart
-  /// // Valid
-  /// profile?.responseData.connectionInfo = {
-  ///   'localPort': 1285,
-  ///   'remotePort': 443,
-  ///   'connectionPoolId': '21x23',
-  /// };
-  ///
-  /// // Invalid
-  /// profile?.responseData.connectionInfo?['localPort'] = 1285;
-  /// ```
-  set connectionInfo(Map<String, dynamic /*String|int*/ >? value) {
-    _checkAndUpdate();
-    if (value == null) {
-      _responseData.remove('connectionInfo');
-    } else {
-      for (final v in value.values) {
-        if (!(v is String || v is int)) {
-          throw ArgumentError(
-            'The values in connectionInfo must be of type String or int.',
-          );
-        }
-      }
-      _responseData['connectionInfo'] = {...value};
-    }
-  }
-
   Map<String, dynamic /*String|int*/ >? get connectionInfo =>
       _responseData['connectionInfo'] as Map<String, dynamic>?;
 

--- a/pkgs/http_profile/test/http_client_request_profile_test.dart
+++ b/pkgs/http_profile/test/http_client_request_profile_test.dart
@@ -77,4 +77,66 @@ void main() {
     expect(eventFromGetter.timestamp, DateTime.parse('2024-03-22'));
     expect(eventFromGetter.name, 'an event');
   });
+
+  test('populating HttpClientRequestProfile.connectionInfo', () async {
+    final requestData = backingMap['requestData'] as Map<String, dynamic>;
+    final responseData = backingMap['responseData'] as Map<String, dynamic>;
+    expect(requestData['connectionInfo'], isNull);
+    expect(responseData['connectionInfo'], isNull);
+    expect(profile.responseData.connectionInfo, isNull);
+
+    profile.connectionInfo = {
+      'localPort': 1285,
+      'remotePort': 443,
+      'connectionPoolId': '21x23'
+    };
+
+    final connectionInfoFromRequestData =
+        requestData['connectionInfo'] as Map<String, dynamic>;
+    final connectionInfoFromResponseData =
+        responseData['connectionInfo'] as Map<String, dynamic>;
+    expect(connectionInfoFromRequestData['localPort'], 1285);
+    expect(connectionInfoFromResponseData['localPort'], 1285);
+    expect(connectionInfoFromRequestData['remotePort'], 443);
+    expect(connectionInfoFromResponseData['remotePort'], 443);
+    expect(connectionInfoFromRequestData['connectionPoolId'], '21x23');
+    expect(connectionInfoFromResponseData['connectionPoolId'], '21x23');
+
+    final connectionInfoFromGetter = profile.responseData.connectionInfo!;
+    expect(connectionInfoFromGetter['localPort'], 1285);
+    expect(connectionInfoFromGetter['remotePort'], 443);
+    expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
+  });
+
+  test('HttpClientRequestProfile.connectionInfo = null', () async {
+    profile.connectionInfo = {
+      'localPort': 1285,
+      'remotePort': 443,
+      'connectionPoolId': '21x23'
+    };
+
+    final requestData = backingMap['requestData'] as Map<String, dynamic>;
+    final connectionInfoFromRequestData =
+        requestData['connectionInfo'] as Map<String, dynamic>;
+    final responseData = backingMap['responseData'] as Map<String, dynamic>;
+    final connectionInfoFromResponseData =
+        responseData['connectionInfo'] as Map<String, dynamic>;
+    expect(connectionInfoFromRequestData['localPort'], 1285);
+    expect(connectionInfoFromResponseData['localPort'], 1285);
+    expect(connectionInfoFromRequestData['remotePort'], 443);
+    expect(connectionInfoFromResponseData['remotePort'], 443);
+    expect(connectionInfoFromRequestData['connectionPoolId'], '21x23');
+    expect(connectionInfoFromResponseData['connectionPoolId'], '21x23');
+
+    final connectionInfoFromGetter = profile.responseData.connectionInfo!;
+    expect(connectionInfoFromGetter['localPort'], 1285);
+    expect(connectionInfoFromGetter['remotePort'], 443);
+    expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
+
+    profile.connectionInfo = null;
+
+    expect(requestData['connectionInfo'], isNull);
+    expect(responseData['connectionInfo'], isNull);
+    expect(profile.responseData.connectionInfo, isNull);
+  });
 }

--- a/pkgs/http_profile/test/http_profile_request_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_request_data_test.dart
@@ -56,56 +56,6 @@ void main() {
     expect(profile.requestData.endTime, DateTime.parse('2024-03-23'));
   });
 
-  test('populating HttpClientRequestProfile.requestData.connectionInfo',
-      () async {
-    final requestData = backingMap['requestData'] as Map<String, dynamic>;
-    expect(requestData['connectionInfo'], isNull);
-    expect(profile.requestData.connectionInfo, isNull);
-
-    profile.requestData.connectionInfo = {
-      'localPort': 1285,
-      'remotePort': 443,
-      'connectionPoolId': '21x23'
-    };
-
-    final connectionInfoFromBackingMap =
-        requestData['connectionInfo'] as Map<String, dynamic>;
-    expect(connectionInfoFromBackingMap['localPort'], 1285);
-    expect(connectionInfoFromBackingMap['remotePort'], 443);
-    expect(connectionInfoFromBackingMap['connectionPoolId'], '21x23');
-
-    final connectionInfoFromGetter = profile.requestData.connectionInfo!;
-    expect(connectionInfoFromGetter['localPort'], 1285);
-    expect(connectionInfoFromGetter['remotePort'], 443);
-    expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
-  });
-
-  test('HttpClientRequestProfile.requestData.connectionInfo = null', () async {
-    final requestData = backingMap['requestData'] as Map<String, dynamic>;
-
-    profile.requestData.connectionInfo = {
-      'localPort': 1285,
-      'remotePort': 443,
-      'connectionPoolId': '21x23'
-    };
-
-    final connectionInfoFromBackingMap =
-        requestData['connectionInfo'] as Map<String, dynamic>;
-    expect(connectionInfoFromBackingMap['localPort'], 1285);
-    expect(connectionInfoFromBackingMap['remotePort'], 443);
-    expect(connectionInfoFromBackingMap['connectionPoolId'], '21x23');
-
-    final connectionInfoFromGetter = profile.requestData.connectionInfo!;
-    expect(connectionInfoFromGetter['localPort'], 1285);
-    expect(connectionInfoFromGetter['remotePort'], 443);
-    expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
-
-    profile.requestData.connectionInfo = null;
-
-    expect(requestData['connectionInfo'], isNull);
-    expect(profile.requestData.connectionInfo, isNull);
-  });
-
   test('populating HttpClientRequestProfile.requestData.contentLength',
       () async {
     final requestData = backingMap['requestData'] as Map<String, dynamic>;

--- a/pkgs/http_profile/test/http_profile_response_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_response_data_test.dart
@@ -52,56 +52,6 @@ void main() {
     expect(redirectFromGetter.location, 'https://images.example.com/1');
   });
 
-  test('populating HttpClientRequestProfile.responseData.connectionInfo',
-      () async {
-    final responseData = backingMap['responseData'] as Map<String, dynamic>;
-    expect(responseData['connectionInfo'], isNull);
-    expect(profile.responseData.connectionInfo, isNull);
-
-    profile.responseData.connectionInfo = {
-      'localPort': 1285,
-      'remotePort': 443,
-      'connectionPoolId': '21x23'
-    };
-
-    final connectionInfoFromBackingMap =
-        responseData['connectionInfo'] as Map<String, dynamic>;
-    expect(connectionInfoFromBackingMap['localPort'], 1285);
-    expect(connectionInfoFromBackingMap['remotePort'], 443);
-    expect(connectionInfoFromBackingMap['connectionPoolId'], '21x23');
-
-    final connectionInfoFromGetter = profile.responseData.connectionInfo!;
-    expect(connectionInfoFromGetter['localPort'], 1285);
-    expect(connectionInfoFromGetter['remotePort'], 443);
-    expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
-  });
-
-  test('HttpClientRequestProfile.responseData.connectionInfo = null', () async {
-    final responseData = backingMap['responseData'] as Map<String, dynamic>;
-
-    profile.responseData.connectionInfo = {
-      'localPort': 1285,
-      'remotePort': 443,
-      'connectionPoolId': '21x23'
-    };
-
-    final connectionInfoFromBackingMap =
-        responseData['connectionInfo'] as Map<String, dynamic>;
-    expect(connectionInfoFromBackingMap['localPort'], 1285);
-    expect(connectionInfoFromBackingMap['remotePort'], 443);
-    expect(connectionInfoFromBackingMap['connectionPoolId'], '21x23');
-
-    final connectionInfoFromGetter = profile.responseData.connectionInfo!;
-    expect(connectionInfoFromGetter['localPort'], 1285);
-    expect(connectionInfoFromGetter['remotePort'], 443);
-    expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
-
-    profile.responseData.connectionInfo = null;
-
-    expect(responseData['connectionInfo'], isNull);
-    expect(profile.responseData.connectionInfo, isNull);
-  });
-
   test('populating HttpClientRequestProfile.responseData.headersListValues',
       () async {
     final responseData = backingMap['responseData'] as Map<String, dynamic>;


### PR DESCRIPTION
The request and response always use the same connection, so it's unnecessary to have both `HttpProfileRequestData.connectionInfo` and `HttpProfileResponseData.connectionInfo` fields. This PR deletes those fields and adds a `HttpClientRequestProfile.connectionInfo` field.

This PR does not change the way backing maps are populated. Doing so will require updates to the dart:io Service Extension spec. I have created this issue to track that: https://github.com/dart-lang/sdk/issues/55305.