### PR TITLE
Fix the connectionInfo getter

### DIFF
--- a/pkgs/http_profile/lib/src/http_client_request_profile.dart
+++ b/pkgs/http_profile/lib/src/http_client_request_profile.dart
@@ -115,10 +115,11 @@ final class HttpClientRequestProfile {
   }
 
   Map<String, dynamic /*String|int*/ >? get connectionInfo =>
-      requestData._data['connectionInfo'] == null
+      requestData._requestData['connectionInfo'] == null
           ? null
           : UnmodifiableMapView(
-              requestData._data['connectionInfo'] as Map<String, dynamic>,
+              requestData._requestData['connectionInfo']
+                  as Map<String, dynamic>,
             );
 
   /// Details about the request.

--- a/pkgs/http_profile/lib/src/http_profile_response_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_response_data.dart
@@ -68,9 +68,6 @@ final class HttpProfileResponseData {
   List<int> get bodyBytes =>
       UnmodifiableListView(_data['responseBodyBytes'] as List<int>);
 
-  Map<String, dynamic /*String|int*/ >? get connectionInfo =>
-      _responseData['connectionInfo'] as Map<String, dynamic>?;
-
   /// The response headers where duplicate headers are represented using a list
   /// of values.
   ///

--- a/pkgs/http_profile/test/http_client_request_profile_test.dart
+++ b/pkgs/http_profile/test/http_client_request_profile_test.dart
@@ -83,7 +83,7 @@ void main() {
     final responseData = backingMap['responseData'] as Map<String, dynamic>;
     expect(requestData['connectionInfo'], isNull);
     expect(responseData['connectionInfo'], isNull);
-    expect(profile.responseData.connectionInfo, isNull);
+    expect(profile.connectionInfo, isNull);
 
     profile.connectionInfo = {
       'localPort': 1285,
@@ -102,7 +102,7 @@ void main() {
     expect(connectionInfoFromRequestData['connectionPoolId'], '21x23');
     expect(connectionInfoFromResponseData['connectionPoolId'], '21x23');
 
-    final connectionInfoFromGetter = profile.responseData.connectionInfo!;
+    final connectionInfoFromGetter = profile.connectionInfo!;
     expect(connectionInfoFromGetter['localPort'], 1285);
     expect(connectionInfoFromGetter['remotePort'], 443);
     expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
@@ -128,7 +128,7 @@ void main() {
     expect(connectionInfoFromRequestData['connectionPoolId'], '21x23');
     expect(connectionInfoFromResponseData['connectionPoolId'], '21x23');
 
-    final connectionInfoFromGetter = profile.responseData.connectionInfo!;
+    final connectionInfoFromGetter = profile.connectionInfo!;
     expect(connectionInfoFromGetter['localPort'], 1285);
     expect(connectionInfoFromGetter['remotePort'], 443);
     expect(connectionInfoFromGetter['connectionPoolId'], '21x23');
@@ -137,6 +137,6 @@ void main() {
 
     expect(requestData['connectionInfo'], isNull);
     expect(responseData['connectionInfo'], isNull);
-    expect(profile.responseData.connectionInfo, isNull);
+    expect(profile.connectionInfo, isNull);
   });
 }


### PR DESCRIPTION
- `HttpClientRequestProfile.connectionInfo` was using the wrong map location to fetch it's data
---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
