### PR TITLE
Ignore errors added to `bodySink`s

### DIFF
--- a/pkgs/http_profile/lib/src/http_client_request_profile.dart
+++ b/pkgs/http_profile/lib/src/http_client_request_profile.dart
@@ -147,12 +147,13 @@ final class HttpClientRequestProfile {
     responseData = HttpProfileResponseData._(_data, _updated);
     _data['requestBodyBytes'] = <int>[];
     requestData._body.stream.listen(
-      (final bytes) => (_data['requestBodyBytes'] as List<int>).addAll(bytes),
-    );
+        (final bytes) => (_data['requestBodyBytes'] as List<int>).addAll(bytes),
+        onError: (e) {});
     _data['responseBodyBytes'] = <int>[];
     responseData._body.stream.listen(
-      (final bytes) => (_data['responseBodyBytes'] as List<int>).addAll(bytes),
-    );
+        (final bytes) =>
+            (_data['responseBodyBytes'] as List<int>).addAll(bytes),
+        onError: (e) {});
     // This entry is needed to support the updatedSince parameter of
     // ext.dart.io.getHttpProfile.
     _updated();

--- a/pkgs/http_profile/lib/src/http_profile_request_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_request_data.dart
@@ -55,6 +55,9 @@ final class HttpProfileRequestData {
       _data['requestData'] as Map<String, dynamic>;
 
   /// A sink that can be used to record the body of the request.
+  ///
+  /// Errors added to [bodySink] (for example with [StreamSink.addError]) are
+  /// ignored.
   StreamSink<List<int>> get bodySink => _body.sink;
 
   /// The body of the request represented as an unmodifiable list of bytes.

--- a/pkgs/http_profile/lib/src/http_profile_response_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_response_data.dart
@@ -62,6 +62,9 @@ final class HttpProfileResponseData {
           .map(HttpProfileRedirectData._fromJson));
 
   /// A sink that can be used to record the body of the response.
+  ///
+  /// Errors added to [bodySink] (for example with [StreamSink.addError]) are
+  /// ignored.
   StreamSink<List<int>> get bodySink => _body.sink;
 
   /// The body of the response represented as an unmodifiable list of bytes.

--- a/pkgs/http_profile/test/http_profile_request_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_request_data_test.dart
@@ -348,9 +348,11 @@ void main() {
     expect(profile.requestData.bodyBytes, isEmpty);
 
     profile.requestData.bodySink.add([1, 2, 3]);
+    profile.requestData.bodySink.addError('this is an error');
+    profile.requestData.bodySink.add([4, 5]);
     await profile.requestData.close();
 
-    expect(requestBodyBytes, [1, 2, 3]);
-    expect(profile.requestData.bodyBytes, [1, 2, 3]);
+    expect(requestBodyBytes, [1, 2, 3, 4, 5]);
+    expect(profile.requestData.bodyBytes, [1, 2, 3, 4, 5]);
   });
 }

--- a/pkgs/http_profile/test/http_profile_response_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_response_data_test.dart
@@ -392,9 +392,11 @@ void main() {
     expect(profile.responseData.bodyBytes, isEmpty);
 
     profile.responseData.bodySink.add([1, 2, 3]);
+    profile.responseData.bodySink.addError('this is an error');
+    profile.responseData.bodySink.add([4, 5]);
     await profile.responseData.close();
 
-    expect(responseBodyBytes, [1, 2, 3]);
-    expect(profile.responseData.bodyBytes, [1, 2, 3]);
+    expect(responseBodyBytes, [1, 2, 3, 4, 5]);
+    expect(profile.responseData.bodyBytes, [1, 2, 3, 4, 5]);
   });
 }


### PR DESCRIPTION
This makes it easier to split any streams passed into the HTTP client API without triggering uncaught exceptions.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
