### PR TITLE
Add eq, toString and hash methods to HttpProfileRedirectData

### DIFF
--- a/pkgs/http_profile/lib/src/http_profile_response_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_response_data.dart
@@ -36,6 +36,21 @@ class HttpProfileRedirectData {
         'method': _method,
         'location': _location,
       };
+
+  @override
+  bool operator ==(Object other) =>
+      (other is HttpProfileRedirectData) &&
+      (statusCode == other.statusCode &&
+          method == other.method &&
+          location == other.location);
+
+  @override
+  int get hashCode => Object.hashAll([statusCode, method, location]);
+
+  @override
+  String toString() =>
+      'HttpProfileRedirectData(statusCode: $statusCode, method: $method, '
+      'location: $location)';
 }
 
 /// Describes details about a response to an HTTP request.

--- a/pkgs/http_profile/test/http_profile_response_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_response_data_test.dart
@@ -87,13 +87,13 @@ void main() {
     expect(redirectFromBackingMap['method'], 'GET');
     expect(redirectFromBackingMap['location'], 'https://images.example.com/1');
 
-    expect(
-        profile.responseData.redirects,
-        HttpProfileRedirectData(
-          statusCode: 301,
-          method: 'GET',
-          location: 'https://images.example.com/1',
-        ));
+    expect(profile.responseData.redirects, [
+      HttpProfileRedirectData(
+        statusCode: 301,
+        method: 'GET',
+        location: 'https://images.example.com/1',
+      )
+    ]);
   });
 
   test('populating HttpClientRequestProfile.responseData.headersListValues',

--- a/pkgs/http_profile/test/http_profile_response_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_response_data_test.dart
@@ -35,7 +35,7 @@ void main() {
               statusCode: 302, method: 'GET', location: 'http://somewhere'));
     });
 
-    test('equal', () {
+    test('not equal', () {
       expect(
           HttpProfileRedirectData(
               statusCode: 302, method: 'GET', location: 'http://somewhere'),

--- a/pkgs/http_profile/test/http_profile_response_data_test.dart
+++ b/pkgs/http_profile/test/http_profile_response_data_test.dart
@@ -26,6 +26,48 @@ void main() {
     backingMap = profileBackingMaps.lastOrNull!;
   });
 
+  group('HttpProfileRedirectData', () {
+    test('equal', () {
+      expect(
+          HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://somewhere'),
+          HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://somewhere'));
+    });
+
+    test('equal', () {
+      expect(
+          HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://somewhere'),
+          isNot(Object()));
+      expect(
+          HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://somewhere'),
+          isNot(HttpProfileRedirectData(
+              statusCode: 303, method: 'GET', location: 'http://somewhere')));
+      expect(
+          HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://somewhere'),
+          isNot(HttpProfileRedirectData(
+              statusCode: 302, method: 'POST', location: 'http://somewhere')));
+      expect(
+          HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://somewhere'),
+          isNot(HttpProfileRedirectData(
+              statusCode: 302, method: 'GET', location: 'http://notthere')));
+    });
+
+    test('hash', () {
+      expect(
+          HttpProfileRedirectData(
+                  statusCode: 302, method: 'GET', location: 'http://somewhere')
+              .hashCode,
+          HttpProfileRedirectData(
+                  statusCode: 302, method: 'GET', location: 'http://somewhere')
+              .hashCode);
+    });
+  });
+
   test('calling HttpClientRequestProfile.responseData.addRedirect', () async {
     final responseData = backingMap['responseData'] as Map<String, dynamic>;
     final redirectsFromBackingMap =
@@ -45,11 +87,13 @@ void main() {
     expect(redirectFromBackingMap['method'], 'GET');
     expect(redirectFromBackingMap['location'], 'https://images.example.com/1');
 
-    expect(profile.responseData.redirects.length, 1);
-    final redirectFromGetter = profile.responseData.redirects.first;
-    expect(redirectFromGetter.statusCode, 301);
-    expect(redirectFromGetter.method, 'GET');
-    expect(redirectFromGetter.location, 'https://images.example.com/1');
+    expect(
+        profile.responseData.redirects,
+        HttpProfileRedirectData(
+          statusCode: 301,
+          method: 'GET',
+          location: 'https://images.example.com/1',
+        ));
   });
 
   test('populating HttpClientRequestProfile.responseData.headersListValues',


### PR DESCRIPTION

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
