### PR TITLE
Use WebSocketConnectionClosed for operations after WebSocket close

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.4.1-wip
 
 * Upgrade to `package:ffigen` 11.0.0.
+* Bring `WebSocket` behavior in line with the documentation by throwing
+  `WebSocketConnectionClosed` rather `StateError` when attempting to send
+  data to or close an already closed `CupertinoWebSocket`.
 
 ## 1.4.0
 

--- a/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
@@ -106,6 +106,10 @@ class CupertinoWebSocket implements WebSocket {
   /// Handle an incoming message from the peer and schedule receiving the next
   /// message.
   void _handleMessage(URLSessionWebSocketMessage value) {
+    if (_events.isClosed) {
+      return;
+    }
+
     late WebSocketEvent event;
     switch (value.type) {
       case URLSessionWebSocketMessageType.urlSessionWebSocketMessageTypeString:
@@ -160,7 +164,7 @@ class CupertinoWebSocket implements WebSocket {
   @override
   void sendBytes(Uint8List b) {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
     _task
         .sendMessage(URLSessionWebSocketMessage.fromData(Data.fromList(b)))
@@ -170,7 +174,7 @@ class CupertinoWebSocket implements WebSocket {
   @override
   void sendText(String s) {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
     _task
         .sendMessage(URLSessionWebSocketMessage.fromString(s))
@@ -180,7 +184,7 @@ class CupertinoWebSocket implements WebSocket {
   @override
   Future<void> close([int? code, String? reason]) async {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
 
     if (code != null) {

--- a/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
@@ -106,9 +106,7 @@ class CupertinoWebSocket implements WebSocket {
   /// Handle an incoming message from the peer and schedule receiving the next
   /// message.
   void _handleMessage(URLSessionWebSocketMessage value) {
-    if (_events.isClosed) {
-      return;
-    }
+    if (_events.isClosed) return;
 
     late WebSocketEvent event;
     switch (value.type) {

--- a/pkgs/web_socket/CHANGELOG.md
+++ b/pkgs/web_socket/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.3
+
+- Bring the behavior in line with the documentation by throwing
+  `WebSocketConnectionClosed` rather `StateError` when attempting to send
+  data to or close an already closed `WebSocket`.
+
 ## 0.1.2
 
 - Fix a `StateError` in `IOWebSocket` when data is received from the peer

--- a/pkgs/web_socket/lib/src/browser_web_socket.dart
+++ b/pkgs/web_socket/lib/src/browser_web_socket.dart
@@ -104,7 +104,7 @@ class BrowserWebSocket implements WebSocket {
   @override
   void sendBytes(Uint8List b) {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
     // Silently discards the data if the connection is closed.
     _webSocket.send(b.jsify()!);
@@ -113,7 +113,7 @@ class BrowserWebSocket implements WebSocket {
   @override
   void sendText(String s) {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
     // Silently discards the data if the connection is closed.
     _webSocket.send(s.jsify()!);
@@ -122,7 +122,7 @@ class BrowserWebSocket implements WebSocket {
   @override
   Future<void> close([int? code, String? reason]) async {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
 
     checkCloseCode(code);

--- a/pkgs/web_socket/lib/src/io_web_socket.dart
+++ b/pkgs/web_socket/lib/src/io_web_socket.dart
@@ -86,7 +86,7 @@ class IOWebSocket implements WebSocket {
   @override
   void sendBytes(Uint8List b) {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
     _webSocket.add(b);
   }
@@ -94,7 +94,7 @@ class IOWebSocket implements WebSocket {
   @override
   void sendText(String s) {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
     _webSocket.add(s);
   }
@@ -102,7 +102,7 @@ class IOWebSocket implements WebSocket {
   @override
   Future<void> close([int? code, String? reason]) async {
     if (_events.isClosed) {
-      throw StateError('WebSocket is closed');
+      throw WebSocketConnectionClosed();
     }
 
     checkCloseCode(code);

--- a/pkgs/web_socket/pubspec.yaml
+++ b/pkgs/web_socket/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Any easy-to-use library for communicating with WebSockets
   that has multiple implementations.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/web_socket
-version: 0.1.2
+version: 0.1.3
 
 environment:
   sdk: ^3.3.0


### PR DESCRIPTION
- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
