### PR TITLE
Make the cupertino_http workflow work after 'macos-latest' upgrade

### DIFF
--- a/.github/workflows/cupertino.yml
+++ b/.github/workflows/cupertino.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: macos-11
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: pkgs/cupertino_http
@@ -49,9 +49,10 @@ jobs:
         if: always() && steps.install.outcome == 'success'
       - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9
         with:
-          model: 'iPhone 8'
+          os: iOS
+          os_version: '>=12.0'
       - name: Run tests
         run: |
           cd example
           flutter pub get
-          flutter test --timeout=12000s integration_test/main.dart
+          flutter test integration_test/main.dart

--- a/.github/workflows/cupertino.yml
+++ b/.github/workflows/cupertino.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Analyze code
         run: flutter analyze --fatal-infos
         if: always() && steps.install.outcome == 'success'
-      - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9
-        with:
-          model: 'iPhone 8'
       - name: Run tests
         run: |
           cd example

--- a/.github/workflows/cupertino.yml
+++ b/.github/workflows/cupertino.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Analyze code
         run: flutter analyze --fatal-infos
         if: always() && steps.install.outcome == 'success'
+      - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9
+        with:
+          model: 'iPhone 8'
       - name: Run tests
         run: |
           cd example

--- a/.github/workflows/cupertino.yml
+++ b/.github/workflows/cupertino.yml
@@ -54,4 +54,4 @@ jobs:
         run: |
           cd example
           flutter pub get
-          flutter test --timeout=1200s integration_test/main.dart
+          flutter test --timeout=12000s integration_test/main.dart

--- a/.github/workflows/cupertino.yml
+++ b/.github/workflows/cupertino.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: macos-latest
+    runs-on: macos-11
     defaults:
       run:
         working-directory: pkgs/cupertino_http

--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.4.1-wip
 
 * Upgrade to `package:ffigen` 11.0.0.
+* Update minimum supported iOS/macOS versions to be in sync with the minimum
+  (best effort) supported for Flutter: iOS 12, macOS 10.14
 
 ## 1.4.0
 

--- a/pkgs/cupertino_http/ios/cupertino_http.podspec
+++ b/pkgs/cupertino_http/ios/cupertino_http.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '12.0'
   s.requires_arc = []
 
   # Flutter.framework does not contain a i386 slice.

--- a/pkgs/cupertino_http/macos/cupertino_http.podspec
+++ b/pkgs/cupertino_http/macos/cupertino_http.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.dependency 'FlutterMacOS'
   s.requires_arc = []
 
-  s.platform = :osx, '10.11'
+  s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION
- The new version of `macos-latest` does not support iPhone 8. To reduce the amount of churn, express the device constraints in terms of iOS version. 
- Set the plugin version constraints to match the minimums supported by Flutter.
---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
