### PR TITLE
Eagerly free resources on `CupertinoClient.close()`

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 * Upgrade to `package:ffigen` 11.0.0.
 * Bring `WebSocket` behavior in line with the documentation by throwing
-  `WebSocketConnectionClosed` rather `StateError` when attempting to send
+  `WebSocketConnectionClosed` rather than `StateError` when attempting to send
   data to or close an already closed `CupertinoWebSocket`.
 * Update minimum supported iOS/macOS versions to be in sync with the minimum
-  (best effort) supported for Flutter: iOS 12, macOS 10.14
+  (best effort) supported for Flutter: iOS 12, macOS 10.14.
+* Eagerly free resources on `CupertinoClient.close()`.
 
 ## 1.4.0
 

--- a/pkgs/cupertino_http/lib/src/cupertino_api.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_api.dart
@@ -1613,4 +1613,12 @@ class URLSession extends _ObjectHolder<ncb.NSURLSession> {
         onWebSocketTaskClosed: _onWebSocketTaskClosed);
     return task;
   }
+
+  /// Free resources related to this session after the last task completes.
+  /// Returns immediately.
+  ///
+  /// See [NSURLSession finishTasksAndInvalidate](https://developer.apple.com/documentation/foundation/nsurlsession/1407428-finishtasksandinvalidate)
+  void finishTasksAndInvalidate() {
+    _nsObject.finishTasksAndInvalidate();
+  }
 }

--- a/pkgs/cupertino_http/lib/src/cupertino_client.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_client.dart
@@ -228,6 +228,7 @@ class CupertinoClient extends BaseClient {
 
   @override
   void close() {
+    _urlSession?.finishTasksAndInvalidate();
     _urlSession = null;
   }
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1131

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
