### PR TITLE
[cronet] Use the same host and Android emulator architecture.

### DIFF
--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -57,5 +57,6 @@ jobs:
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
           api-level: 30
+          arch: arm64-v8a
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -57,7 +57,5 @@ jobs:
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
           api-level: 21
-          arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
-          profile: pixel
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -6,12 +6,12 @@ on:
       - main
       - master
     paths:
-      - '.github/workflows/cronet.yaml'
+      - '.github/workflows/cronet.yml'
       - 'pkgs/cronet_http/**'
       - 'pkgs/http_client_conformance_tests/**'
   pull_request:
     paths:
-      - '.github/workflows/cronet.yaml'
+      - '.github/workflows/cronet.yml'
       - 'pkgs/cronet_http/**'
       - 'pkgs/http_client_conformance_tests/**'
   schedule:

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cronetHttpNoPlay: ['false', 'true']
@@ -56,7 +56,7 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: 30
-          arch: arm64-v8a
+          api-level: 21
+          arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -56,7 +56,7 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: 21
+          api-level: 34
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
         cronetHttpNoPlay: ['false', 'true']
@@ -56,9 +56,6 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: 21
+          api-level: 30
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/
-          ram-size: 8192MB
-          disk-size: 8192MB
-          heap-size: 2048MB

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cronetHttpNoPlay: ['false', 'true']

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -59,3 +59,6 @@ jobs:
           api-level: 21
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/
+          ram-size: 8192MB
+          disk-size: 8192MB
+          heap-size: 2048MB

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -56,7 +56,7 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: 34
+          api-level: 21
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/


### PR DESCRIPTION
`macos-latest` now refers to ARM machines, so use `ubuntu-latest` to be able to continue to use `x86_64` Android images.

Why not just use ARM images? Because they are not supported below Android API v30.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
