### PR TITLE
Mark flutter .metadata files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .github/workflows/dart.yml linguist-generated=true
 tool/ci.sh linguist-generated=true
+pkgs/*/.metadata linguist-generated=true


### PR DESCRIPTION
Removes one file with a comment indicating it should not be hand edited
from the default view for github PR diffs.
