### PR TITLE
pkgs/http_client_conformance_tests: add boolean flag `supportsFoldedHeaders`

### DIFF
--- a/pkgs/http_client_conformance_tests/lib/http_client_conformance_tests.dart
+++ b/pkgs/http_client_conformance_tests/lib/http_client_conformance_tests.dart
@@ -64,6 +64,9 @@ export 'src/server_errors_test.dart' show testServerErrors;
 /// If [canReceiveSetCookieHeaders] is `false` then tests that require that
 /// "set-cookie" headers be received by the client will not be run.
 ///
+/// If [supportsFoldedHeaders] is `false` then the tests that assume that the
+/// [Client] can parse folded headers will be skipped.
+///
 /// The tests are run against a series of HTTP servers that are started by the
 /// tests. If the tests are run in the browser, then the test servers are
 /// started in another process. Otherwise, the test servers are run in-process.
@@ -74,6 +77,7 @@ void testAll(
   bool redirectAlwaysAllowed = false,
   bool canWorkInIsolates = true,
   bool preservesMethodCase = false,
+  bool supportsFoldedHeaders = true,
   bool canSendCookieHeaders = false,
   bool canReceiveSetCookieHeaders = false,
 }) {
@@ -86,7 +90,8 @@ void testAll(
       canStreamResponseBody: canStreamResponseBody);
   testRequestHeaders(clientFactory());
   testRequestMethods(clientFactory(), preservesMethodCase: preservesMethodCase);
-  testResponseHeaders(clientFactory());
+  testResponseHeaders(clientFactory(),
+      supportsFoldedHeaders: supportsFoldedHeaders);
   testResponseStatusLine(clientFactory());
   testRedirect(clientFactory(), redirectAlwaysAllowed: redirectAlwaysAllowed);
   testServerErrors(clientFactory());

--- a/pkgs/http_client_conformance_tests/lib/src/response_headers_tests.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/response_headers_tests.dart
@@ -11,7 +11,8 @@ import 'response_headers_server_vm.dart'
     if (dart.library.js_interop) 'response_headers_server_web.dart';
 
 /// Tests that the [Client] correctly processes response headers.
-void testResponseHeaders(Client client) async {
+void testResponseHeaders(Client client,
+    {bool supportsFoldedHeaders = true}) async {
   group('server headers', () {
     late String host;
     late StreamChannel<Object?> httpServerChannel;
@@ -177,6 +178,8 @@ void testResponseHeaders(Client client) async {
             allOf(matches(RegExp(r'BAR {0,3}[ \t]? {0,7}[ \t]? {0,3}BAZ')),
                 contains(' ')));
       });
-    });
+    },
+        skip:
+            !supportsFoldedHeaders ? 'does not support folded headers' : false);
   });
 }


### PR DESCRIPTION
Items in this PR:

- [x] Added a boolean flag `supportsFoldedHeaders` to `testResponseHeaders`
- [x] Added relevant documentation in `pkgs/http_client_conformance_tests/lib/http_client_conformance_tests.dart`
- [x] Closes #1219  

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
