### PR TITLE
http_client_conformance_tests: Fix inconsistent test server behavior

### DIFF
--- a/pkgs/http_client_conformance_tests/lib/src/request_cookies_server.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/request_cookies_server.dart
@@ -25,7 +25,7 @@ void hybridMain(StreamChannel<Object?> channel) async {
       final request = utf8.decoder.bind(socket).transform(const LineSplitter());
 
       final cookies = <String>[];
-      request.listen((line) {
+      await for (final line in request) {
         if (line.toLowerCase().startsWith('cookie:')) {
           cookies.add(line);
         }
@@ -33,8 +33,9 @@ void hybridMain(StreamChannel<Object?> channel) async {
         if (line.isEmpty) {
           // A blank line indicates the end of the headers.
           channel.sink.add(cookies);
+          break;
         }
-      });
+      }
 
       socket.writeAll(
         [


### PR DESCRIPTION
Items in this PR:

- [x] Updates to `testRequestCookies` server, to fix a synchronization issue for reading contents from the socket/request. Please refer to https://github.com/dart-lang/http/pull/1223#discussion_r1625056264 that discusses the issue.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
