### PR TITLE
Call out more limitations of runWithClient

### DIFF
--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -198,6 +198,10 @@ Client? get zoneClient {
 /// and the convenience HTTP functions (e.g. [http.get]). If [clientFactory]
 /// returns `Client()` then the default [Client] is used.
 ///
+/// Only fresh `Client` instances using the default constructor are impacted.
+/// HTTP requests made using `dart:io` or `dart:html` APIs,
+/// or using specifically instantiated client implementations, are not affected.
+///
 /// When used in the context of Flutter, [runWithClient] should be called before
 /// [`WidgetsFlutterBinding.ensureInitialized`](https://api.flutter.dev/flutter/widgets/WidgetsFlutterBinding/ensureInitialized.html)
 /// because Flutter runs in whatever [Zone] was current at the time that the


### PR DESCRIPTION
Towards #828

Add a section in the `runWithClient` doc that mentions HTTP requests
which _aren't_ affected by usage of this API - specifically requests
made through the SDK core libraries, or through instantiating specific
client implementations.
