### PR TITLE
Document that runWithClient should not be used with Flutter

### DIFF
--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -202,34 +202,26 @@ Client? get zoneClient {
 /// HTTP requests made using `dart:io` or `dart:html` APIs,
 /// or using specifically instantiated client implementations, are not affected.
 ///
-/// When used in the context of Flutter, [runWithClient] should be called before
-/// [`WidgetsFlutterBinding.ensureInitialized`](https://api.flutter.dev/flutter/widgets/WidgetsFlutterBinding/ensureInitialized.html)
-/// because Flutter runs in whatever [Zone] was current at the time that the
-/// bindings were initialized.
-///
-/// [`runApp`](https://api.flutter.dev/flutter/widgets/runApp.html) calls
-/// [`WidgetsFlutterBinding.ensureInitialized`](https://api.flutter.dev/flutter/widgets/WidgetsFlutterBinding/ensureInitialized.html)
-/// so the easiest approach is to call that in [body]:
-/// ```
-/// void main() {
-///  var clientFactory = Client.new; // Constructs the default client.
-///  if (Platform.isAndroid) {
-///     clientFactory = MyAndroidHttpClient.new;
-///  }
-///  runWithClient(() => runApp(const MyApp()), clientFactory);
-/// }
-/// ```
-///
 /// If [runWithClient] is used and the environment defines
 /// `no_default_http_client=true` then generated binaries may be smaller e.g.
 /// ```shell
-/// $ flutter build appbundle --dart-define=no_default_http_client=true ...
 /// $ dart compile exe --define=no_default_http_client=true ...
 /// ```
 ///
 /// If `no_default_http_client=true` is set then any call to the [Client]
 /// factory (i.e. `Client()`) outside of the [Zone] created by [runWithClient]
 /// will throw [StateError].
+///
+/// > [!IMPORTANT]
+/// > Flutter does not guarantee that callbacks are executed in a particular
+/// > [Zone].
+/// >
+/// > Instead of using [runWithClient], Flutter developers can use a framework,
+/// > such as [`package:provider`](https://pub.dev/packages/provider), to make
+/// > a [Client] available throughout their applications.
+/// >
+/// > See the
+/// > [Flutter Http Example](https://github.com/dart-lang/http/tree/master/pkgs/flutter_http_example).
 R runWithClient<R>(R Function() body, Client Function() clientFactory,
         {ZoneSpecification? zoneSpecification}) =>
     runZoned(body,


### PR DESCRIPTION
I opted not to examine the possibility of using `Zone.registerCallback` because I think that it would be awkward to use in practice.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
