### PR TITLE
Clarify when Client.close must be called

### DIFF
--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -148,8 +148,10 @@ abstract interface class Client {
 
   /// Closes the client and cleans up any resources associated with it.
   ///
-  /// It's important to close each client when it's done being used; failing to
-  /// do so can cause the Dart process to hang.
+  /// Some clients may maintain a pool of network connections that will not
+  /// be disconnected until the client is closed. This may cause programs run
+  /// using the Dart SDK (but **not** the Flutter SDK) to not terminate until
+  /// the client is closed.
   ///
   /// Once [close] is called, no other methods should be called. If [close] is
   /// called while other asynchronous methods are running, the behavior is

--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -148,10 +148,11 @@ abstract interface class Client {
 
   /// Closes the client and cleans up any resources associated with it.
   ///
-  /// Some clients may maintain a pool of network connections that will not
-  /// be disconnected until the client is closed. This may cause programs run
-  /// using the Dart SDK (but **not** the Flutter SDK) to not terminate until
-  /// the client is closed.
+  /// Some clients maintain a pool of network connections that will not be
+  /// disconnected until the client is closed. This may cause programs using
+  /// using the Dart SDK (`dart run`, `dart test`, `dart compile`, etc.) to
+  /// not terminate until the client is closed. Programs run using the Flutter
+  /// SDK can still terminate even with an active connection pool.
   ///
   /// Once [close] is called, no other methods should be called. If [close] is
   /// called while other asynchronous methods are running, the behavior is


### PR DESCRIPTION
I'm not happy with this phrasing so any advice would be appreciated.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
