### PR TITLE
Add WebSocket usage examples to cupertino_http

### DIFF
--- a/pkgs/cupertino_http/README.md
+++ b/pkgs/cupertino_http/README.md
@@ -49,7 +49,6 @@ void main() async {
 [CupertinoWebSocket][] provides a [package:web_socket][] [WebSocket][]
 implementation.
 
-
 ```dart
 import 'package:cupertino_http/cupertino_http.dart';
 import 'package:web_socket/web_socket.dart';

--- a/pkgs/cupertino_http/README.md
+++ b/pkgs/cupertino_http/README.md
@@ -46,6 +46,32 @@ void main() async {
 }
 ```
 
+[CupertinoWebSocket][] provides a [package:web_socket][] [WebSocket][]
+implementation.
+
+
+```dart
+import 'package:cupertino_http/cupertino_http.dart';
+import 'package:web_socket/web_socket.dart';
+
+void main() async {
+  final socket = await CupertinoWebSocket.connect(
+      Uri.parse('wss://ws.postman-echo.com/raw'));
+
+  socket.events.listen((e) async {
+    switch (e) {
+      case TextDataReceived(text: final text):
+        print('Received Text: $text');
+        await socket.close();
+      case BinaryDataReceived(data: final data):
+        print('Received Binary: $data');
+      case CloseReceived(code: final code, reason: final reason):
+        print('Connection to server closed: $code [$reason]');
+    }
+  });
+}
+```
+
 You can also use the [Foundation URL Loading System] API directly.
 
 ```dart
@@ -63,6 +89,9 @@ final task = session.dataTaskWithCompletionHandler(URLRequest.fromUrl(url),
 task.resume();
 ```
 
-[package:http Client]: https://pub.dev/documentation/http/latest/http/Client-class.html
-[Foundation URL Loading System]: https://developer.apple.com/documentation/foundation/url_loading_system
+[CupertinoWebSocket]: https://pub.dev/documentation/cupertino_http/latest/cupertino_http/CupertinoWebSocket-class.html
 [dart:io HttpClient]: https://api.dart.dev/stable/dart-io/HttpClient-class.html
+[Foundation URL Loading System]: https://developer.apple.com/documentation/foundation/url_loading_system
+[package:http Client]: https://pub.dev/documentation/http/latest/http/Client-class.html
+[package:web_socket]: https://pub.dev/packages/web_socket
+[WebSocket]: https://pub.dev/documentation/web_socket/latest/web_socket/WebSocket-class.html

--- a/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
@@ -25,6 +25,28 @@ class ConnectionException extends WebSocketException {
 ///
 /// NOTE: the [WebSocket] interface is currently experimental and may change in
 /// the future.
+///
+/// ```dart
+/// import 'package:cupertino_http/cupertino_http.dart';
+/// import 'package:web_socket/web_socket.dart';
+///
+/// void main() async {
+///   final socket = await CupertinoWebSocket.connect(
+///       Uri.parse('wss://ws.postman-echo.com/raw'));
+///
+///   socket.events.listen((e) async {
+///     switch (e) {
+///       case TextDataReceived(text: final text):
+///         print('Received Text: $text');
+///         await socket.close();
+///       case BinaryDataReceived(data: final data):
+///         print('Received Binary: $data');
+///       case CloseReceived(code: final code, reason: final reason):
+///         print('Connection to server closed: $code [$reason]');
+///     }
+///   });
+/// }
+/// ```
 class CupertinoWebSocket implements WebSocket {
   /// Create a new WebSocket connection using the
   /// [NSURLSessionWebSocketTask API](https://developer.apple.com/documentation/foundation/nsurlsessionwebsockettask).


### PR DESCRIPTION
1. Update the README
2. Add an example to `CupertinoWebSocket`

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
