### PR TITLE
fix(http_client_conformance_tests): multipart server

### DIFF
--- a/pkgs/http_client_conformance_tests/lib/src/multipart_tests.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/multipart_tests.dart
@@ -34,8 +34,9 @@ void testMultipartRequests(Client client,
       request.files.add(MultipartFile.fromString('file1', 'Hello World'));
 
       await client.send(request);
-      final (headers, body) =
-          await httpServerQueue.next as (Map<String, List<String>>, String);
+      final serverRequest = await httpServerQueue.next as List;
+      final headers = (serverRequest[0] as Map).cast<String, List<Object?>>();
+      final body = serverRequest[1] as String;
       expect(headers['content-length']!.single, '${request.contentLength}');
       expect(headers['content-type']!.single,
           startsWith('multipart/form-data; boundary='));


### PR DESCRIPTION
There are 2 issues fixed in multipart server:
- Server can be closed before response is emitted
- Tuple can't be JSON encoded

I've only tested it with `fetch_client` but I think that browser client should support multipart requests as well.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
