### PR TITLE
Convert a `java.lang.OutOfMemoryError` into a `ClientException`

### DIFF
--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.3-wip
+
+* Throw `ClientException` if `CronetClient.send` runs out of Java heap while
+  allocating memory for the request body.
+
 ## 1.3.2
 
 * Upgrade `package:jni` to 0.10.1 and `package:jnigen` to 0.10.0 to fix method

--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -392,8 +392,19 @@ class CronetClient extends BaseClient {
     headers.forEach((k, v) => builder.addHeader(k.toJString(), v.toJString()));
 
     if (body.isNotEmpty) {
+      final JByteBuffer data;
+      try {
+        data = body.toJByteBuffer();
+      } on JniException catch (e) {
+        if (e.message.contains('java.lang.OutOfMemoryError:')) {
+          throw ClientException(
+              'Not enough memory for request body: ${e.message}', request.url);
+        }
+        rethrow;
+      }
+
       builder.setUploadDataProvider(
-          jb.UploadDataProviders.create2(body.toJByteBuffer()), _executor);
+          jb.UploadDataProviders.create2(data), _executor);
     }
     builder.build().start();
     return responseCompleter.future;

--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -396,6 +396,9 @@ class CronetClient extends BaseClient {
       try {
         data = body.toJByteBuffer();
       } on JniException catch (e) {
+        // There are no unit tests for this code. You can verify this behavior
+        // manually by incrementally increasing the amount of body data in
+        // `CronetClient.post` until you get this exception.
         if (e.message.contains('java.lang.OutOfMemoryError:')) {
           throw ClientException(
               'Not enough memory for request body: ${e.message}', request.url);

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cronet_http
-version: 1.3.2
+version: 1.3.3-wip
 description: >-
   An Android Flutter plugin that provides access to the Cronet HTTP client.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1271

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
