### PR TITLE
Migrate to the dart_style DartFormatter API.

### DIFF
--- a/pkgs/http_client_conformance_tests/bin/generate_server_wrappers.dart
+++ b/pkgs/http_client_conformance_tests/bin/generate_server_wrappers.dart
@@ -44,7 +44,8 @@ Future<StreamChannel<Object?>> startServer() async => spawnHybridUri(Uri(
 
 void main() async {
   final files = await Directory('lib/src').list().toList();
-  final formatter = DartFormatter();
+  final formatter =
+      DartFormatter(languageVersion: DartFormatter.latestLanguageVersion);
 
   files.where((file) => file.path.endsWith('_server.dart')).forEach((file) {
     final vmPath = file.path.replaceAll('_server.dart', '_server_vm.dart');

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   async: ^2.8.2
-  dart_style: ^2.2.3
+  dart_style: ^2.3.7
   http: ^1.2.0
   stream_channel: ^2.1.1
   test: ^1.21.2


### PR DESCRIPTION
Going forward, the formatter needs to know what language version it should use to parse input code. This updates the generator to pass in a version. (In this case, since it's just used for code generation, it unconditionally passes in the latest language version, which should be fine.)

Fix #1304.
