### PR TITLE
Fix a potential exponential backtracking issue when parsing quoted headers

### DIFF
--- a/pkgs/http_parser/CHANGELOG.md
+++ b/pkgs/http_parser/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.2-wip
+
+* Fixed a bug where parsing quoted header values could require a regex to
+  backtrack
+* Fixed a bug where quoted header values containing escaped quotes would not
+  be correctly parsed.
+
 ## 4.1.1
 
 * Move to `dart-lang/http` monorepo.

--- a/pkgs/http_parser/lib/src/scan.dart
+++ b/pkgs/http_parser/lib/src/scan.dart
@@ -11,6 +11,11 @@ final token = RegExp(r'[^()<>@,;:"\\/[\]?={} \t\x00-\x1F\x7F]+');
 final _lws = RegExp(r'(?:\r\n)?[ \t]+');
 
 /// A quoted string.
+///
+/// [RFC-2616 2.2](https://datatracker.ietf.org/doc/html/rfc2616#section-2.2)
+/// defines the `quoted-string` production. This expression is identical to
+/// the RFC definition expect that, in this regex, `qdtext` is not allowed to
+/// contain `"\"`.
 final _quotedString = RegExp(r'"(?:[^"\x00-\x1F\x7F\\]|\\.)*"');
 
 /// A quoted pair.

--- a/pkgs/http_parser/lib/src/scan.dart
+++ b/pkgs/http_parser/lib/src/scan.dart
@@ -11,7 +11,7 @@ final token = RegExp(r'[^()<>@,;:"\\/[\]?={} \t\x00-\x1F\x7F]+');
 final _lws = RegExp(r'(?:\r\n)?[ \t]+');
 
 /// A quoted string.
-final _quotedString = RegExp(r'"(?:[^"\x00-\x1F\x7F]|\\.)*"');
+final _quotedString = RegExp(r'"(?:[^"\x00-\x1F\x7F\\]|\\.)*"');
 
 /// A quoted pair.
 final _quotedPair = RegExp(r'\\(.)');
@@ -54,7 +54,7 @@ List<T> parseList<T>(StringScanner scanner, T Function() parseElement) {
   return result;
 }
 
-/// Parses a single quoted string, and returns its contents.
+/// Parses a double quoted string, and returns its contents.
 ///
 /// If [name] is passed, it's used to describe the expected value if it's not
 /// found.

--- a/pkgs/http_parser/pubspec.yaml
+++ b/pkgs/http_parser/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_parser
-version: 4.1.1
+version: 4.1.2-wip
 description: >-
   A platform-independent package for parsing and serializing HTTP formats.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http_parser

--- a/pkgs/http_parser/test/authentication_challenge_test.dart
+++ b/pkgs/http_parser/test/authentication_challenge_test.dart
@@ -73,6 +73,14 @@ void _singleChallengeTests(
         equals({'realm': 'fblthp, foo=bar', 'baz': 'qux'}));
   });
 
+  test('parses quoted string parameters with surrounding spaces', () {
+    final challenge =
+        parseChallenge('scheme realm= "fblthp, foo=bar" , baz= "qux" ');
+    expect(challenge.scheme, equals('scheme'));
+    expect(challenge.parameters,
+        equals({'realm': 'fblthp, foo=bar', 'baz': 'qux'}));
+  });
+
   test('normalizes the case of the scheme', () {
     final challenge = parseChallenge('ScHeMe realm=fblthp');
     expect(challenge.scheme, equals('scheme'));

--- a/pkgs/http_parser/test/scan_test.dart
+++ b/pkgs/http_parser/test/scan_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:http_parser/src/scan.dart';
+import 'package:string_scanner/string_scanner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('expectQuotedString', () {
+    test('no open quote', () {
+      final scanner = StringScanner('test"');
+      expect(
+          () => expectQuotedString(scanner),
+          throwsA(isA<StringScannerException>()
+              .having((e) => e.offset, 'offset', 0)
+              .having((e) => e.message, 'message', 'expected quoted string.')
+              .having((e) => e.source, 'source', 'test"')));
+      expect(scanner.isDone, isFalse);
+      expect(scanner.lastMatch, null);
+      expect(scanner.position, 0);
+    });
+
+    test('no close quote', () {
+      final scanner = StringScanner('"test');
+      expect(
+          () => expectQuotedString(scanner),
+          throwsA(isA<StringScannerException>()
+              .having((e) => e.offset, 'offset', 0)
+              .having((e) => e.message, 'message', 'expected quoted string.')
+              .having((e) => e.source, 'source', '"test')));
+      expect(scanner.isDone, isFalse);
+      expect(scanner.lastMatch, null);
+      expect(scanner.position, 0);
+    });
+
+    test('simple quoted', () {
+      final scanner = StringScanner('"test"');
+      expect(expectQuotedString(scanner), 'test');
+      expect(scanner.isDone, isTrue);
+      expect(scanner.lastMatch?.group(0), '"test"');
+      expect(scanner.position, 6);
+    });
+
+    test(r'escaped \', () {
+      final scanner = StringScanner(r'"escaped: \\"');
+      expect(expectQuotedString(scanner), r'escaped: \');
+      expect(scanner.isDone, isTrue);
+      expect(scanner.lastMatch?.group(0), r'"escaped: \\"');
+      expect(scanner.position, 13);
+    });
+
+    test(r'bare \', () {
+      final scanner = StringScanner(r'"bare: \"');
+      expect(
+          () => expectQuotedString(scanner),
+          throwsA(isA<StringScannerException>()
+              .having((e) => e.offset, 'offset', 0)
+              .having((e) => e.message, 'message', 'expected quoted string.')
+              .having((e) => e.source, 'source', r'"bare: \"')));
+      expect(scanner.isDone, isFalse);
+      expect(scanner.lastMatch, null);
+      expect(scanner.position, 0);
+    });
+
+    test(r'escaped "', () {
+      final scanner = StringScanner(r'"escaped: \""');
+      expect(expectQuotedString(scanner), r'escaped: "');
+      expect(scanner.isDone, isTrue);
+      expect(scanner.lastMatch?.group(0), r'"escaped: \""');
+      expect(scanner.position, 13);
+    });
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1433

@bkonyi Is there a way to verify that this fixes the issue with https://github.com/dart-lang/webdev/security/code-scanning/2 before landing this? Or I could land this but not publish until you can verify the fix.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
