### PR TITLE
Fix browser clients in workers

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 * Fixed default encoding for application/json without a charset
   to use utf8 instead of latin1, ensuring proper JSON decoding.
+* Avoid references to `window` in `BrowserClient`, restoring support for web
+  workers and NodeJS.
 
-## 1.3.0-wip
+## 1.3.0
 
 * Fixed unintended HTML tags in doc comments.
 * Switched `BrowserClient` to use Fetch API instead of `XMLHttpRequest`.


### PR DESCRIPTION
The browser client implementations calls `window.fetch()` to send HTTP requests. This makes it impossible to use the package in contexts where `window` is unavailable, such as web workers or Node.JS.

Instead of using `window`, this PR changes the implementation to just call `fetch()` on the global scope.