### PR TITLE
Http-parser: Make CaseInsensitiveMap be extension type.

### DIFF
--- a/pkgs/http_parser/CHANGELOG.md
+++ b/pkgs/http_parser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.3
+
+* Makes `CaseInsensitiveMap` an extension type.
+  Allows `package:collection` to make the class `final`.
+
 ## 4.1.2
 
 * Fixed a bug where parsing quoted header values could require a regex to

--- a/pkgs/http_parser/lib/src/case_insensitive_map.dart
+++ b/pkgs/http_parser/lib/src/case_insensitive_map.dart
@@ -7,19 +7,20 @@ import 'package:collection/collection.dart';
 /// A map from case-insensitive strings to values.
 ///
 /// Much of HTTP is case-insensitive, so this is useful to have pre-defined.
-class CaseInsensitiveMap<V> extends CanonicalizedMap<String, String, V> {
+extension type CaseInsensitiveMap<V>._(Map<String, V> _)
+    implements Map<String, V> {
   /// Creates an empty case-insensitive map.
-  CaseInsensitiveMap() : super(_canonicalizer);
+  CaseInsensitiveMap()
+      : this._(CanonicalizedMap<String, String, V>(_canonicalize));
 
-  /// Creates a case-insensitive map that is initialized with the key/value
-  /// pairs of [other].
+  /// Creates a case-insensitive map initialized with the entries of [other].
   CaseInsensitiveMap.from(Map<String, V> other)
-      : super.from(other, _canonicalizer);
+      : this._(CanonicalizedMap<String, String, V>.from(other, _canonicalize));
 
-  /// Creates a case-insensitive map that is initialized with the key/value
-  /// pairs of [entries].
+  /// Creates a case-insensitive map initialized with the [entries].
   CaseInsensitiveMap.fromEntries(Iterable<MapEntry<String, V>> entries)
-      : super.fromEntries(entries, _canonicalizer);
+      : this._(CanonicalizedMap<String, String, V>.fromEntries(
+            entries, _canonicalize));
 
-  static String _canonicalizer(String key) => key.toLowerCase();
+  static String _canonicalize(String key) => key.toLowerCase();
 }

--- a/pkgs/http_parser/pubspec.yaml
+++ b/pkgs/http_parser/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_parser
-version: 4.1.2
+version: 4.1.3
 description: >-
   A platform-independent package for parsing and serializing HTTP formats.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http_parser
@@ -14,5 +14,5 @@ dependencies:
   typed_data: ^1.3.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^3.0.0
+  dart_flutter_team_lints: ^3.3.0
   test: ^1.16.6

--- a/pkgs/http_parser/pubspec.yaml
+++ b/pkgs/http_parser/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   typed_data: ^1.3.0
 
 dev_dependencies:
-  dart_flutter_team_lints: ^3.3.0
+  dart_flutter_team_lints: ^3.1.0
   test: ^1.16.6


### PR DESCRIPTION
Avoids extending a class unnecessarily, which *may* pave the way for `package:collection` making the class final.

(Nothing uses that `CaseInsensitiveMap` is a type at all, the constructors could all just be functions returning `Map`.)

Change is not breaking, the type is not publicly visible.