### PR TITLE
Add custom message when terminating a connection

### DIFF
--- a/pkgs/http2/CHANGELOG.md
+++ b/pkgs/http2/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.3.2-wip
+- Add support for providing custom message when terminating a connection.
 
 ## 2.3.1
 

--- a/pkgs/http2/lib/src/connection.dart
+++ b/pkgs/http2/lib/src/connection.dart
@@ -288,8 +288,8 @@ abstract class Connection {
   }
 
   /// Terminates this connection forcefully.
-  Future<void> terminate([int? errorCode]) {
-    return _terminate(errorCode ?? ErrorCode.NO_ERROR);
+  Future<void> terminate([int? errorCode, String? message]) {
+    return _terminate(errorCode ?? ErrorCode.NO_ERROR, message: message);
   }
 
   void _activeStateHandler(bool isActive) =>

--- a/pkgs/http2/lib/transport.dart
+++ b/pkgs/http2/lib/transport.dart
@@ -73,7 +73,7 @@ abstract class TransportConnection {
   Future finish();
 
   /// Terminates this connection forcefully.
-  Future terminate([int? errorCode]);
+  Future terminate([int? errorCode, String? message]);
 }
 
 abstract class ClientTransportConnection extends TransportConnection {


### PR DESCRIPTION
Add support for terminating an http2 connection with a custom message.

This changes allows a dependent project to supply custom debug text to clients of the server when they do not meet certain preconditions.
