### PR TITLE
Improve the reliability of cronet_http/ok_http workflows

### DIFF
--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -59,6 +59,7 @@ jobs:
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
           api-level: 21
+          disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}
           script: cd pkgs/cronet_http/example && flutter test --dart-define=cronetHttpNoPlay=${{ matrix.cronetHttpNoPlay }} --timeout=1200s integration_test/

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -65,7 +65,7 @@ jobs:
           # the tests that rely on Google Play services with the newest API
           # level (34 as of March 2025). The tests that don't rely on Google
           # Play serviecs can test the oldest supported API level.
-          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '34' }} 
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '33' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: linux-4cpu-16GB
+    runs-on: ubuntu-cpu16-ram64
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -44,6 +44,10 @@ jobs:
       - id: install
         name: Install dependencies
         run: flutter pub get
+      - name: Memory
+        run: cat /proc/meminfo
+      - name: CPU
+        run: lscpu
       - name: Check formatting
         if: always() && steps.install.outcome == 'success'
         run: dart format --output=none --set-exit-if-changed .

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -44,10 +44,6 @@ jobs:
       - id: install
         name: Install dependencies
         run: flutter pub get
-      - name: Memory
-        run: cat /proc/meminfo
-      - name: CPU
-        run: lscpu
       - name: Check formatting
         if: always() && steps.install.outcome == 'success'
         run: dart format --output=none --set-exit-if-changed .
@@ -62,7 +58,7 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: 21
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '29' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: ubuntu-latest
+    runs-on: linux-4cpu-16GB
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -65,7 +65,7 @@ jobs:
           # the tests that rely on Google Play services with the newest API
           # level (34 as of March 2025). The tests that don't rely on Google
           # Play serviecs can test the oldest supported API level.
-          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '33' }} 
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '29' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -33,10 +33,6 @@ jobs:
       run:
         working-directory: pkgs/cronet_http
     steps:
-      - name: Delete unnecessary tools 🔧
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          android: false # Don't remove Android tools
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12
         with:

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -24,7 +24,7 @@ jobs:
   verify:
     name: Format & Analyze & Test
     runs-on: ubuntu-cpu16-ram64
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +58,14 @@ jobs:
           # - .github/workflows/cronet.yml
           # - pkgs/cronet_http/android/build.gradle
           # - pkgs/cronet_http/example/android/app/build.gradle
-          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '29' }} 
+
+          # Google Play services does not support older Android API levels;
+          # as of March 2025, they supported API level 23 and higher. Instead
+          # of breaking when support for API level 23 is removed, just run
+          # the tests that rely on Google Play services with the newest API
+          # level (34 as of March 2025). The tests that don't rely on Google
+          # Play serviecs can test the oldest supported API level.
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '34' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Analyze code
         if: always() && steps.install.outcome == 'success'
         run: flutter analyze --fatal-infos
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d
         if: always() && steps.install.outcome == 'success'

--- a/.github/workflows/okhttp.yaml
+++ b/.github/workflows/okhttp.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: linux-4cpu-16GB
+    runs-on: ubuntu-cpu16-ram64
     defaults:
       run:
         working-directory: pkgs/ok_http
@@ -45,6 +45,11 @@ jobs:
       - name: Analyze code
         if: always() && steps.install.outcome == 'success'
         run: flutter analyze --fatal-infos
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d
         if: always() && steps.install.outcome == 'success'

--- a/.github/workflows/okhttp.yaml
+++ b/.github/workflows/okhttp.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   verify:
     name: Format & Analyze & Test
-    runs-on: ubuntu-latest
+    runs-on: linux-4cpu-16GB
     defaults:
       run:
         working-directory: pkgs/ok_http

--- a/.github/workflows/okhttp.yaml
+++ b/.github/workflows/okhttp.yaml
@@ -6,12 +6,12 @@ on:
       - main
       - master
     paths:
-      - '.github/workflows/okhttp.yml'
+      - '.github/workflows/okhttp.yaml'
       - 'pkgs/ok_http/**'
       - 'pkgs/http_client_conformance_tests/**'
   pull_request:
     paths:
-      - '.github/workflows/okhttp.yml'
+      - '.github/workflows/okhttp.yaml'
       - 'pkgs/ok_http/**'
       - 'pkgs/http_client_conformance_tests/**'
   schedule:


### PR DESCRIPTION
Make the `package:cronet_http` CI run more reliably by:
- running it on a better machine
- increasing the timeout to 30 minutes
- don't remove unnecessary tools (takes about 4 minutes, increasing the likelyhood of a timeout)
- enable the KVM for the android emulator
- don't try to use Google Play services with Android API level 21

Make the `package:ok_http` CI run more reliably by:
- correctly identifying the name of the workflow files
- running it on a better machine
- enable the KVM for the android emulator

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
