### PR TITLE
[web_socket] Adds `WebSocketException.toString()`

### DIFF
--- a/pkgs/web_socket/lib/src/web_socket.dart
+++ b/pkgs/web_socket/lib/src/web_socket.dart
@@ -83,6 +83,15 @@ final class CloseReceived extends WebSocketEvent {
 class WebSocketException implements Exception {
   final String message;
   WebSocketException([this.message = '']);
+
+  @override
+  String toString() {
+    if (message.isEmpty) {
+      return 'WebSocketException';
+    } else {
+      return 'WebSocketException: $message';
+    }
+  }
 }
 
 /// Thrown if [WebSocket.sendText], [WebSocket.sendBytes], or


### PR DESCRIPTION
Similar to `WebSocketChannelException` and `ClientException`, overriding the method would provide a readable format when referencing it in logs/consoles.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
