### PR TITLE
[WIP] feat: support abortion of in-flight HTTP requests

### DIFF
--- a/pkgs/http/example/main.dart
+++ b/pkgs/http/example/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert' as convert;
 
 import 'package:http/http.dart' as http;
@@ -9,6 +10,14 @@ void main(List<String> arguments) async {
       Uri.https('www.googleapis.com', '/books/v1/volumes', {'q': '{http}'});
 
   // Await the http get response, then decode the json-formatted response.
+  try {
+    final e =
+        await http.AbortableRequest('GET', url, abortTrigger: Future.error(10))
+            .send();
+    await e.stream.drain<void>();
+  } on http.AbortedRequest {
+    print('Cancelled');
+  }
   var response = await http.get(url);
   if (response.statusCode == 200) {
     var jsonResponse =

--- a/pkgs/http/lib/http.dart
+++ b/pkgs/http/lib/http.dart
@@ -19,6 +19,7 @@ export 'src/base_request.dart';
 export 'src/base_response.dart'
     show BaseResponse, BaseResponseWithUrl, HeadersWithSplitValues;
 export 'src/byte_stream.dart';
+export 'src/abortable.dart';
 export 'src/client.dart' hide zoneClient;
 export 'src/exception.dart';
 export 'src/multipart_file.dart';

--- a/pkgs/http/lib/src/abortable.dart
+++ b/pkgs/http/lib/src/abortable.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'base_request.dart';
+import 'client.dart';
+
+/// Enables a request to be recognised by a [Client] as abortable
+abstract mixin class Abortable implements BaseRequest {
+  /// This request will be aborted if this completes
+  ///
+  /// A common pattern is aborting a request when another event occurs (such as
+  /// a user action). A [Completer] may be used to implement this.
+  ///
+  /// Another pattern is a timeout. Use [Future.delayed] to achieve this.
+  ///
+  /// This future must not complete to an error.
+  ///
+  /// This future may complete at any time - a [AbortedRequest] will be thrown
+  /// by [send]/[Client.send] if it is completed before the request is complete.
+  ///
+  /// Non-'package:http' [Client]s may unexpectedly not support this trigger.
+  abstract final Future<void>? abortTrigger;
+}
+
+/// Thrown when a request is aborted using [Abortable.abortTrigger]
+///
+/// This is not thrown when `abortTrigger` is completed after the request has
+/// already completed.
+class AbortedRequest implements Exception {
+  /// Indicator that the request has been aborted by [Abortable.abortTrigger]
+  const AbortedRequest();
+}

--- a/pkgs/http/lib/src/base_request.dart
+++ b/pkgs/http/lib/src/base_request.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:meta/meta.dart';
 
 import '../http.dart' show ClientException, get;
+import 'abortable.dart';
 import 'base_client.dart';
 import 'base_response.dart';
 import 'byte_stream.dart';
@@ -20,6 +21,10 @@ import 'utils.dart';
 /// [BaseClient.send], which allows the user to provide fine-grained control
 /// over the request properties. However, usually it's easier to use convenience
 /// methods like [get] or [BaseClient.get].
+///
+/// Subclasses/implementers should mixin/implement [Abortable] to support
+/// abortion of requests. A future breaking version of 'package:http' will
+/// merge [Abortable] into [BaseRequest], making it a requirement.
 abstract class BaseRequest {
   /// The HTTP method of the request.
   ///

--- a/pkgs/http/lib/src/multipart_request.dart
+++ b/pkgs/http/lib/src/multipart_request.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:math';
 
+import 'abortable.dart';
 import 'base_request.dart';
 import 'boundary_characters.dart';
 import 'byte_stream.dart';
@@ -159,4 +160,16 @@ class MultipartRequest extends BaseRequest {
         growable: false);
     return '$prefix${String.fromCharCodes(list)}';
   }
+}
+
+/// A [MultipartRequest] which supports abortion using [abortTrigger]
+///
+/// A future breaking version of 'package:http' will merge this into
+/// [MultipartRequest], making it a requirement.
+final class AbortableMultipartRequest extends MultipartRequest with Abortable {
+  AbortableMultipartRequest(super.method, super.url, {this.abortTrigger})
+      : super();
+
+  @override
+  final Future<void>? abortTrigger;
 }

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 
 import 'package:http_parser/http_parser.dart';
 
+import 'abortable.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';
 import 'utils.dart';
@@ -181,4 +182,15 @@ class Request extends BaseRequest {
     if (!finalized) return;
     throw StateError("Can't modify a finalized Request.");
   }
+}
+
+/// A [Request] which supports abortion using [abortTrigger]
+///
+/// A future breaking version of 'package:http' will merge this into [Request],
+/// making it a requirement.
+final class AbortableRequest extends Request with Abortable {
+  AbortableRequest(super.method, super.url, {this.abortTrigger}) : super();
+
+  @override
+  final Future<void>? abortTrigger;
 }

--- a/pkgs/http/lib/src/streamed_request.dart
+++ b/pkgs/http/lib/src/streamed_request.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'abortable.dart';
 import 'base_client.dart';
 import 'base_request.dart';
 import 'byte_stream.dart';
@@ -52,4 +53,16 @@ class StreamedRequest extends BaseRequest {
     super.finalize();
     return ByteStream(_controller.stream);
   }
+}
+
+/// A [StreamedRequest] which supports abortion using [abortTrigger]
+///
+/// A future breaking version of 'package:http' will merge this into
+/// [StreamedRequest], making it a requirement.
+final class AbortableStreamedRequest extends StreamedRequest with Abortable {
+  AbortableStreamedRequest(super.method, super.url, {this.abortTrigger})
+      : super();
+
+  @override
+  final Future<void>? abortTrigger;
 }


### PR DESCRIPTION
Resolves #424, closes #204, closes #424, closes #567
Closes #978, closes #521, closes #602, closes #819

As discussed in #424, this adds an `Abortable` interface for `BaseRequests` that provides an `abortTrigger` which `Client`s may use to abort requests.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
