### PR TITLE
Fix a bug where `ConnectionException.toString` didn't stringify `NSError`

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1-wip
+
+* Make `ConnectionException.toString` more helpful.
+
 ## 2.2.0
 
 * Cancel requests when the response stream is cancelled.

--- a/pkgs/cupertino_http/example/integration_test/web_socket_test.dart
+++ b/pkgs/cupertino_http/example/integration_test/web_socket_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:cupertino_http/cupertino_http.dart';
+import 'package:objective_c/objective_c.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ConnectionException', () {
+    test('toString', () {
+      expect(
+          ConnectionException(
+                  'failed to connect',
+                  NSError.errorWithDomain_code_userInfo_(
+                      'NSURLErrorDomain'.toNSString(), -999, null))
+              .toString(),
+          'CupertinoErrorWebSocketException: failed to connect '
+          '[The operation couldn’t be completed. '
+          '(NSURLErrorDomain error -999.)]');
+    });
+  });
+}

--- a/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
@@ -18,7 +18,8 @@ class ConnectionException extends WebSocketException {
   ConnectionException(super.message, this.error);
 
   @override
-  String toString() => 'CupertinoErrorWebSocketException: $message $error';
+  String toString() => 'CupertinoErrorWebSocketException: $message '
+      '[${error.localizedDescription.toDartString()}]';
 }
 
 /// A [WebSocket] implemented using the

--- a/pkgs/cupertino_http/pubspec.yaml
+++ b/pkgs/cupertino_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cupertino_http
-version: 2.2.0
+version: 2.2.1-wip
 description: >-
   A macOS/iOS Flutter plugin that provides access to the Foundation URL
   Loading System.


### PR DESCRIPTION
- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
