### PR TITLE
[cronet_http] Upgrade to kotlin 1.8.10

### DIFF
--- a/pkgs/cronet_http/example/android/settings.gradle
+++ b/pkgs/cronet_http/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.21" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Fixes this warning:

```
Warning: Flutter support for your project's Kotlin version (1.8.0) will soon be dropped. Please upgrade your Kotlin version to a version of at least 1.8.10 soon.
Alternatively, use the flag "--android-skip-build-dependency-validation" to bypass this check.

Potential fix: Your project's KGP version is typically defined in the plugins block of the `settings.gradle` file (/Users/bquinlan/dart/http/pkgs/cronet_http/example/android/settings.gradle), by a plugin with the id of org.jetbrains.kotlin.android.
If you don't see a plugins block, your project was likely created with an older template version, in which case it is most likely defined in the top-level build.gradle file (/Users/bquinlan/dart/http/pkgs/cronet_http/example/android/build.gradle) by the ext.kotlin_version property.
```

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
