### PR TITLE
✨ Introduce `ClosableBaseClient`

### DIFF
--- a/pkgs/cronet_http/lib/src/cronet_client.dart
+++ b/pkgs/cronet_http/lib/src/cronet_client.dart
@@ -81,6 +81,8 @@ enum CacheMode {
 /// An environment that can be used to make HTTP requests.
 class CronetEngine {
   late final jb.CronetEngine _engine;
+
+  bool get isClosed => _isClosed;
   bool _isClosed = false;
 
   CronetEngine._(this._engine);
@@ -351,9 +353,12 @@ jb.UrlRequestCallbackProxy$UrlRequestCallbackInterface _urlRequestCallbacks(
 /// A HTTP [Client] based on the
 /// [Cronet](https://developer.android.com/guide/topics/connectivity/cronet)
 /// network stack.
-class CronetClient extends BaseClient {
+class CronetClient extends ClosableBaseClient {
   static final _executor = jb.Executors.newCachedThreadPool();
   CronetEngine? _engine;
+
+  @override
+  bool get isClosed => _isClosed;
   bool _isClosed = false;
 
   /// Indicates that [CronetClient] is responsible for closing [_engine].
@@ -414,7 +419,7 @@ class CronetClient extends BaseClient {
     final engine = _engine ?? CronetEngine.build();
     _engine = engine;
 
-    if (engine._isClosed) {
+    if (engine.isClosed) {
       throw ClientException(
           'HTTP request failed. CronetEngine is already closed.', request.url);
     }

--- a/pkgs/cupertino_http/lib/src/cupertino_client.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_client.dart
@@ -94,9 +94,11 @@ class _TaskTracker {
 ///   }
 /// }
 /// ```
-class CupertinoClient extends BaseClient {
+class CupertinoClient extends ClosableBaseClient {
   static final Map<URLSessionTask, _TaskTracker> _tasks = {};
 
+  @override
+  bool get isClosed => _urlSession == null;
   URLSession? _urlSession;
 
   CupertinoClient._(this._urlSession);

--- a/pkgs/http/lib/src/base_client.dart
+++ b/pkgs/http/lib/src/base_client.dart
@@ -106,3 +106,10 @@ abstract mixin class BaseClient implements Client {
   @override
   void close() {}
 }
+
+abstract class ClosableBaseClient extends BaseClient {
+  bool get isClosed;
+
+  @override
+  void close();
+}

--- a/pkgs/http/lib/src/browser_client.dart
+++ b/pkgs/http/lib/src/browser_client.dart
@@ -50,14 +50,17 @@ external JSPromise<Response> _fetch(
 ///
 /// Responses are streamed but requests are not. A request will only be sent
 /// once all the data is available.
-class BrowserClient extends BaseClient {
+class BrowserClient extends ClosableBaseClient {
   /// Whether to send credentials such as cookies or authorization headers for
   /// cross-site requests.
   ///
   /// Defaults to `false`.
   bool withCredentials = false;
 
+  @override
+  bool get isClosed => _isClosed;
   bool _isClosed = false;
+
   final _openRequestAbortControllers = <AbortController>[];
 
   /// Sends an HTTP request and asynchronously returns the response.

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -82,9 +82,13 @@ class _IOStreamedResponseV2 extends IOStreamedResponse
 ///   // would be caught by this handler.
 /// }
 /// ```
-class IOClient extends BaseClient {
+class IOClient extends ClosableBaseClient {
   /// The underlying `dart:io` HTTP client.
   HttpClient? _inner;
+
+  @override
+  bool get isClosed => _isClosed;
+  bool _isClosed = false;
 
   /// Create a new `dart:io`-based HTTP [Client].
   ///
@@ -103,7 +107,7 @@ class IOClient extends BaseClient {
   /// Sends an HTTP request and asynchronously returns the response.
   @override
   Future<IOStreamedResponse> send(BaseRequest request) async {
-    if (_inner == null) {
+    if (_inner == null || _isClosed) {
       throw ClientException(
           'HTTP request failed. Client is already closed.', request.url);
     }
@@ -243,5 +247,6 @@ class IOClient extends BaseClient {
       _inner!.close(force: true);
       _inner = null;
     }
+    _isClosed = true;
   }
 }

--- a/pkgs/ok_http/lib/src/ok_http_client.dart
+++ b/pkgs/ok_http/lib/src/ok_http_client.dart
@@ -213,8 +213,11 @@ Future<String?> choosePrivateKeyAlias({
 ///   }
 /// }
 /// ```
-class OkHttpClient extends BaseClient {
+class OkHttpClient extends ClosableBaseClient {
   late bindings.OkHttpClient _client;
+
+  @override
+  bool get isClosed => _isClosed;
   bool _isClosed = false;
 
   /// The configuration for this client, applied on a per-call basis.


### PR DESCRIPTION
When I was trying to write tests against the closed state of clients, I found that all closed states are private. To obtain the closed state without breaking the `BaseClient`, the PR introduces the `ClosableBaseClient` specifically for the close interfaces.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
