### PR TITLE
Only set the charset when the body is set for certain mime types

### DIFF
--- a/pkgs/cronet_http/example/pubspec.yaml
+++ b/pkgs/cronet_http/example/pubspec.yaml
@@ -30,8 +30,7 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# TODO(brianquinlan): Remove this when a release version of `package:http`
-# supports abortable requests.
+# Use the checked-in version of `package:http` for consistency with tests.
 dependency_overrides:
   http:
     path: ../../http/

--- a/pkgs/cupertino_http/example/pubspec.yaml
+++ b/pkgs/cupertino_http/example/pubspec.yaml
@@ -39,7 +39,8 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# Use the checked-in version of `package:http` for consistency with tests
+# Use the path version of `package:http` so that the behavior matches the
+# expectations in http_client_conformance_tests.
 dependency_overrides:
   http:
     path: ../../http/

--- a/pkgs/cupertino_http/example/pubspec.yaml
+++ b/pkgs/cupertino_http/example/pubspec.yaml
@@ -38,3 +38,8 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# Use the checked-in version of `package:http` for consistency with tests
+dependency_overrides:
+  http:
+    path: ../../http/

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 2.0.0-wip
+## 1.6.0-wip
 
 * **Breaking** Change the behavior of `Request.body` so that a charset
-  parameter is only added for text and XML media types.
+  parameter is only added for text and XML media types. This brings the
+  behavior of `package:http` in line with RFC-8259.
 
 ## 1.5.0
 

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.0-beta.3
+
+* **Breaking** Change the behavior of `Request.body` so that a charset
+  parameter is only added for text and XML media types.
+
 ## 1.5.0-beta.2
 
 * Fixed a bug in `IOClient` where the `HttpClient`'s response stream was

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -61,8 +61,9 @@ class Request extends BaseRequest {
     _checkFinalized();
     _defaultEncoding = value;
     var contentType = _contentType;
-    if (contentType == null || !contentType.parameters.containsKey('charset'))
+    if (contentType == null || !contentType.parameters.containsKey('charset')) {
       return;
+    }
     _contentType = contentType.change(parameters: {'charset': value.name});
   }
 
@@ -106,7 +107,8 @@ class Request extends BaseRequest {
   /// header, use [bodyBytes].
   String get body => encoding.decode(bodyBytes);
 
-  bool _should(MediaType? contentType) => (contentType != null &&
+  bool _should(MediaType? contentType) =>
+      contentType != null &&
       // RFC 8259, 9 says that "charset" is not defined for JSON.
       // Some non-text, non-xml formats do specify charset
       // (e.g. application/news-checkgroups) but the user will have to set the
@@ -118,7 +120,7 @@ class Request extends BaseRequest {
           contentType.mimeType == 'application/xml' ||
           contentType.mimeType == 'application/xml-external-parsed-entity' ||
           contentType.mimeType == 'application/xml-dtd' ||
-          contentType.mimeType.endsWith('+xml')));
+          contentType.mimeType.endsWith('+xml'));
 
   set body(String value) {
     // IANA defines known media types here:

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -106,7 +106,9 @@ class Request extends BaseRequest {
     var contentType = _contentType;
     if (contentType == null) {
       _contentType = MediaType('text', 'plain', {'charset': encoding.name});
-    } else if (!contentType.parameters.containsKey('charset')) {
+    } else if ((contentType.type == 'text' ||
+            contentType.mimeType == 'application/xml') &&
+        !contentType.parameters.containsKey('charset')) {
       _contentType = contentType.change(parameters: {'charset': encoding.name});
     }
   }

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -61,7 +61,8 @@ class Request extends BaseRequest {
     _checkFinalized();
     _defaultEncoding = value;
     var contentType = _contentType;
-    if (contentType == null) return;
+    if (contentType == null || !contentType.parameters.containsKey('charset'))
+      return;
     _contentType = contentType.change(parameters: {'charset': value.name});
   }
 
@@ -105,6 +106,20 @@ class Request extends BaseRequest {
   /// header, use [bodyBytes].
   String get body => encoding.decode(bodyBytes);
 
+  bool _should(MediaType? contentType) => (contentType != null &&
+      // RFC 8259, 9 says that "charset" is not defined for JSON.
+      // Some non-text, non-xml formats do specify charset
+      // (e.g. application/news-checkgroups) but the user will have to set the
+      // charset themselves if those cases.
+      (contentType.type == 'text' ||
+          // XML media types defined by RFC 7303.
+          // Note that some media types (e.g. cda+xml) specify that the
+          // charset, when present, must be utf-8.
+          contentType.mimeType == 'application/xml' ||
+          contentType.mimeType == 'application/xml-external-parsed-entity' ||
+          contentType.mimeType == 'application/xml-dtd' ||
+          contentType.mimeType.endsWith('+xml')));
+
   set body(String value) {
     // IANA defines known media types here:
     // https://www.iana.org/assignments/media-types/media-types.xhtml
@@ -112,14 +127,7 @@ class Request extends BaseRequest {
     var contentType = _contentType;
     if (contentType == null) {
       _contentType = MediaType('text', 'plain', {'charset': encoding.name});
-    } else if ((contentType.type == 'text' ||
-            // XML media types defined by RFC 7303.
-            // Note that some media types (e.g. cda+xml) specify that the
-            // charset, when present, must be utf-8.
-            contentType.mimeType == 'application/xml' ||
-            contentType.mimeType == 'application/xml-external-parsed-entity' ||
-            contentType.mimeType == 'application/xml-dtd' ||
-            contentType.mimeType.endsWith('+xml')) &&
+    } else if (_should(_contentType) &&
         // RFC 8259, 9 says that "charset" is not defined for JSON.
         // Some non-text, non-xml formats do specify charset
         // (e.g. application/news-checkgroups) but the user will have to set the

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -15,7 +15,7 @@ import 'utils.dart';
 /// An HTTP request where the entire request body is known in advance.
 class Request extends BaseRequest {
   /// Whether the given MIME type should have a 'charset' parameter.
-  bool _shouldHaveCharset(MediaType? contentType) =>
+  static bool _shouldHaveCharset(MediaType? contentType) =>
       contentType != null &&
       // RFC 8259, section 9 says that "charset" is not defined for JSON.
       // Some uncommon non-text, non-xml types do specify charset

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -17,10 +17,10 @@ class Request extends BaseRequest {
   /// Whether the given MIME type should have a 'charset' parameter.
   bool _shouldHaveCharset(MediaType? contentType) =>
       contentType != null &&
-      // RFC 8259, 9 says that "charset" is not defined for JSON.
-      // Some non-text, non-xml formats do specify charset
+      // RFC 8259, section 9 says that "charset" is not defined for JSON.
+      // Some uncommon non-text, non-xml types do specify charset
       // (e.g. application/news-checkgroups) but the user will have to set the
-      // charset themselves if those cases.
+      // charset themselves for those types.
       (contentType.type == 'text' ||
           // XML media types defined by RFC 7303.
           // Note that some media types (e.g. cda+xml) specify that the

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -115,8 +115,8 @@ class Request extends BaseRequest {
   /// `charset` parameter.
   ///
   /// If request has `Content-Type` header with MIME media type name `text` or
-  /// is an XML MIME type (e.g. `application/xml` or `image/svg+xml) but
-  /// without `charset` parameter, then the `charset` parameter will be set to
+  /// is an XML MIME type (e.g. `application/xml` or `image/svg+xml`) without
+  /// `charset` parameter, then the `charset` parameter will be set to
   /// [encoding].
   ///
   /// To set the body of the request, without changing the `Content-Type`

--- a/pkgs/http/lib/src/request.dart
+++ b/pkgs/http/lib/src/request.dart
@@ -24,7 +24,7 @@ class Request extends BaseRequest {
       (contentType.type == 'text' ||
           // XML media types defined by RFC 7303.
           // Note that some media types (e.g. cda+xml) specify that the
-          // charset, when present, must be utf-8.
+          // charset, when present, must be utf-8. We do not enforce this.
           contentType.mimeType == 'application/xml' ||
           contentType.mimeType == 'application/xml-external-parsed-entity' ||
           contentType.mimeType == 'application/xml-dtd' ||

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 1.5.0-beta.2
+version: 1.5.0-beta.3
 description: A composable, multi-platform, Future-based API for HTTP requests.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http
 

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 2.0.0-wip
+version: 1.6.0-wip
 description: A composable, multi-platform, Future-based API for HTTP requests.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http
 

--- a/pkgs/http/test/io/http_test.dart
+++ b/pkgs/http/test/io/http_test.dart
@@ -158,9 +158,7 @@ void main() {
             'method': 'POST',
             'path': '/',
             'headers': {
-              'content-type': [
-                'application/x-www-form-urlencoded; charset=utf-8'
-              ],
+              'content-type': ['application/x-www-form-urlencoded'],
               'content-length': ['40'],
               'accept-encoding': ['gzip'],
               'user-agent': ['Dart'],
@@ -273,9 +271,7 @@ void main() {
             'method': 'PUT',
             'path': '/',
             'headers': {
-              'content-type': [
-                'application/x-www-form-urlencoded; charset=utf-8'
-              ],
+              'content-type': ['application/x-www-form-urlencoded'],
               'content-length': ['40'],
               'accept-encoding': ['gzip'],
               'user-agent': ['Dart'],
@@ -388,9 +384,7 @@ void main() {
             'method': 'PATCH',
             'path': '/',
             'headers': {
-              'content-type': [
-                'application/x-www-form-urlencoded; charset=utf-8'
-              ],
+              'content-type': ['application/x-www-form-urlencoded'],
               'content-length': ['40'],
               'accept-encoding': ['gzip'],
               'user-agent': ['Dart'],

--- a/pkgs/http/test/request_test.dart
+++ b/pkgs/http/test/request_test.dart
@@ -189,23 +189,12 @@ void main() {
       expect(request.headers, containsPair('content-type', 'application/json'));
     });
 
-    test(
-        'is set to application/x-www-form-urlencoded with charset utf-8 if '
-        'bodyFields is set', () {
+    test('is set to application/x-www-form-urlencoded if bodyFields is set',
+        () {
       var request = http.Request('POST', dummyUrl)
         ..bodyFields = {'hello': 'world'};
       expect(request.headers['Content-Type'],
-          equals('application/x-www-form-urlencoded; charset=utf-8'));
-    });
-
-    test(
-        'is set to application/x-www-form-urlencoded with the given charset '
-        'if bodyFields and encoding are set', () {
-      var request = http.Request('POST', dummyUrl)
-        ..encoding = latin1
-        ..bodyFields = {'hello': 'world'};
-      expect(request.headers['Content-Type'],
-          equals('application/x-www-form-urlencoded; charset=iso-8859-1'));
+          equals('application/x-www-form-urlencoded'));
     });
 
     test(
@@ -218,20 +207,25 @@ void main() {
           equals('text/plain; charset=iso-8859-1'));
     });
 
-    test('is modified to include utf-8 if body is set', () {
+    test('is modified to include utf-8 if body is set and mine type is text',
+        () {
       var request = http.Request('POST', dummyUrl);
-      request.headers['Content-Type'] = 'application/json';
+      request.headers['Content-Type'] = 'text/plain';
       request.body = '{"hello": "world"}';
-      expect(request.headers['Content-Type'],
-          equals('application/json; charset=utf-8'));
+      expect(
+          request.headers['Content-Type'], equals('text/plain; charset=utf-8'));
     });
 
-    test('is modified to include the given encoding if encoding is set', () {
+    test(
+        'is modified to include the given encoding if encoding is set and '
+        'mine type is text', () {
       var request = http.Request('POST', dummyUrl);
-      request.headers['Content-Type'] = 'application/json';
-      request.encoding = latin1;
+      request.headers['Content-Type'] = 'text/plain';
+      request
+        ..body = 'Hello World!'
+        ..encoding = latin1;
       expect(request.headers['Content-Type'],
-          equals('application/json; charset=iso-8859-1'));
+          equals('text/plain; charset=iso-8859-1'));
     });
 
     test('has its charset overridden by an explicit encoding', () {

--- a/pkgs/http/test/request_test.dart
+++ b/pkgs/http/test/request_test.dart
@@ -211,9 +211,27 @@ void main() {
         () {
       var request = http.Request('POST', dummyUrl);
       request.headers['Content-Type'] = 'text/plain';
-      request.body = '{"hello": "world"}';
+      request.body = 'Hello World!';
       expect(
           request.headers['Content-Type'], equals('text/plain; charset=utf-8'));
+    });
+
+    test('is modified to include utf-8 if body is set and mine type is xml',
+        () {
+      var request = http.Request('POST', dummyUrl);
+      request.headers['Content-Type'] = 'application/xml';
+      request.body = '<?xml...';
+      expect(request.headers['Content-Type'],
+          equals('application/xml; charset=utf-8'));
+    });
+
+    test(
+        'is not modified to include utf-8 if body is set and mine type is json',
+        () {
+      var request = http.Request('POST', dummyUrl);
+      request.headers['Content-Type'] = 'application/json';
+      request.body = '{"hello": "world"}';
+      expect(request.headers['Content-Type'], equals('application/json'));
     });
 
     test(

--- a/pkgs/http/test/request_test.dart
+++ b/pkgs/http/test/request_test.dart
@@ -207,7 +207,7 @@ void main() {
           equals('text/plain; charset=iso-8859-1'));
     });
 
-    test('is modified to include utf-8 if body is set and mine type is text',
+    test('is modified to include utf-8 if body is set and mime type is text',
         () {
       var request = http.Request('POST', dummyUrl);
       request.headers['Content-Type'] = 'text/plain';
@@ -216,7 +216,7 @@ void main() {
           request.headers['Content-Type'], equals('text/plain; charset=utf-8'));
     });
 
-    test('is modified to include utf-8 if body is set and mine type is xml',
+    test('is modified to include utf-8 if body is set and mime type is xml',
         () {
       var request = http.Request('POST', dummyUrl);
       request.headers['Content-Type'] = 'application/xml';
@@ -226,7 +226,7 @@ void main() {
     });
 
     test(
-        'is not modified to include utf-8 if body is set and mine type is json',
+        'is not modified to include utf-8 if body is set and mime type is json',
         () {
       var request = http.Request('POST', dummyUrl);
       request.headers['Content-Type'] = 'application/json';
@@ -236,7 +236,7 @@ void main() {
 
     test(
         'is modified to include the given encoding if encoding is set and '
-        'mine type is text', () {
+        'mime type is text', () {
       var request = http.Request('POST', dummyUrl);
       request.headers['Content-Type'] = 'text/plain';
       request
@@ -244,6 +244,29 @@ void main() {
         ..encoding = latin1;
       expect(request.headers['Content-Type'],
           equals('text/plain; charset=iso-8859-1'));
+    });
+
+    test(
+        'is modified to include the given encoding if encoding is set and '
+        'mime type is xml', () {
+      var request = http.Request('POST', dummyUrl);
+      request.headers['Content-Type'] = 'application/xml';
+      request
+        ..body = '<?xml...'
+        ..encoding = latin1;
+      expect(request.headers['Content-Type'],
+          equals('application/xml; charset=iso-8859-1'));
+    });
+
+    test(
+        'is not modified to include the given encoding if encoding is set mime '
+        'type is json', () {
+      var request = http.Request('POST', dummyUrl);
+      request.headers['Content-Type'] = 'application/json';
+      request
+        ..body = '{"hello": "world"}'
+        ..encoding = latin1;
+      expect(request.headers['Content-Type'], equals('application/json'));
     });
 
     test('has its charset overridden by an explicit encoding', () {

--- a/pkgs/http_client_conformance_tests/lib/src/request_body_tests.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/request_body_tests.dart
@@ -78,8 +78,7 @@ void testRequestBody(Client client) {
       final serverReceivedContentType = await httpServerQueue.next;
       final serverReceivedBody = await httpServerQueue.next;
 
-      expect(serverReceivedContentType,
-          ['application/x-www-form-urlencoded; charset=utf-8']);
+      expect(serverReceivedContentType, ['application/x-www-form-urlencoded']);
       expect(serverReceivedBody, 'key=value');
     });
 
@@ -90,8 +89,7 @@ void testRequestBody(Client client) {
       final serverReceivedContentType = await httpServerQueue.next;
       final serverReceivedBody = await httpServerQueue.next;
 
-      expect(serverReceivedContentType,
-          ['application/x-www-form-urlencoded; charset=plus2']);
+      expect(serverReceivedContentType, ['application/x-www-form-urlencoded']);
       expect(serverReceivedBody, 'gau;r]hqa'); // key=value
     });
 
@@ -149,7 +147,7 @@ void testRequestBody(Client client) {
       final serverReceivedContentType = await httpServerQueue.next;
       final serverReceivedBody = await httpServerQueue.next as String;
 
-      expect(serverReceivedContentType, ['image/png; charset=plus2']);
+      expect(serverReceivedContentType, ['image/png']);
       expect(serverReceivedBody.codeUnits, [1, 2, 3, 4, 5]);
     });
 

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -11,9 +11,7 @@ environment:
 dependencies:
   async: ^2.8.2
   dart_style: ">=2.3.7 <4.0.0"
-  # TODO(brianquinlan): Tighten this version constraint when package:http 2.0
-  # is released.
-  http: ">=1.2.0 <3.0.0"
+  http: ^1.2.0
   stream_channel: ^2.1.1
   test: ^1.21.2
 

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -11,7 +11,9 @@ environment:
 dependencies:
   async: ^2.8.2
   dart_style: ">=2.3.7 <4.0.0"
-  http: ">=1.2.0 <3.0.0" # XXX
+  # TODO(brianquinlan): Tighten this version constraint when package:http 2.0
+  # is released.
+  http: ">=1.2.0 <3.0.0"
   stream_channel: ^2.1.1
   test: ^1.21.2
 

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -11,11 +11,10 @@ environment:
 dependencies:
   async: ^2.8.2
   dart_style: ">=2.3.7 <4.0.0"
-  http: ^1.2.0
+  http: ">=1.2.0 <3.0.0" # XXX
   stream_channel: ^2.1.1
   test: ^1.21.2
 
-# TODO(brianquinlan): Remove dependency_overrides when package:http 1.5.0 is released.
 dependency_overrides:
   http:
     path: ../http

--- a/pkgs/ok_http/example/pubspec.yaml
+++ b/pkgs/ok_http/example/pubspec.yaml
@@ -36,8 +36,8 @@ flutter:
   assets:
     - test_certs/  # Used in integration tests.
 
-# TODO(brianquinlan): Remove this when a release version of `package:http`
-# supports abortable requests.
+# Use the path version of `package:http` so that the behavior matches the
+# expectations in http_client_conformance_tests.
 dependency_overrides:
   http:
     path: ../../http/


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1438

NOTE: The `charset` parameter is not defined for [`application/x-www-form-urlencoded`](https://www.iana.org/assignments/media-types/application/x-www-form-urlencoded) so the changes to those tests should not break anything.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
