### PR TITLE
[http2] Gracefully receive headers on canceled streams

### DIFF
--- a/pkgs/http2/CHANGELOG.md
+++ b/pkgs/http2/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1-wip
+
+- Gracefully handle receiving headers on a stream that the client has canceled. (#1799)
+
 ## 3.0.0
 
 - Require Dart SDK `3.7.0`.

--- a/pkgs/http2/lib/src/streams/stream_handler.dart
+++ b/pkgs/http2/lib/src/streams/stream_handler.dart
@@ -613,12 +613,12 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
             _handleHeadersFrame(newStream, frame);
             _newStreamsC.add(newStream);
           } else {
-            // A server cannot open new streams to the client. The only way
-            // for a server to start a new stream is via a PUSH_PROMISE_FRAME.
-            throw ProtocolException(
-              'HTTP/2 clients cannot receive HEADER_FRAMEs as a connection'
-              'attempt.',
-            );
+            // We must be able to receive header frames for streams that have
+            // already been closed. This can occur if we send RST_STREAM while
+            // the server already had header frames in flight.
+            //
+            // Still respond with an error, as the stream is closed.
+            throw _throwStreamClosedException(frame.header.streamId);
           }
         } else if (frame is WindowUpdateFrame) {
           if (frameBelongsToIdleStream()) {

--- a/pkgs/http2/pubspec.yaml
+++ b/pkgs/http2/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http2
-version: 3.0.0
+version: 3.0.1-wip
 description: A HTTP/2 implementation in Dart.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http2
 


### PR DESCRIPTION
If a client opens a stream and then cancels it, the server may have already sent response frames back. The HTTP/2 spec says that the client MUST be prepared to receive any such frames. We already handle this correctly for data frames, but prior to this patch, header frames on a canceled stream would cause the whole connection to be torn down. This patch fixes that.

Fixes #1799.

Test Plan:
Unit tests included. Before this change, the new test would fail with "Connection is being forcefully terminated. (errorCode: 1)".

wchargin-branch: http2-headers-after-cancel

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR:
  - [x] Changelog updated
  - [x] Pubspec version revved
  - [x] Tests included
