### PR TITLE
Prepare to release packages http/cronet_http/cupertino_http supporting request cancellation

### DIFF
--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.0-wip
+## 1.5.0
 
 * Add the ability to abort requests.
 * Upgrade Cronet dependencies version.

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cronet_http
-version: 1.5.0-wip
+version: 1.5.0
 description: >-
   An Android Flutter plugin that provides access to the Cronet HTTP client.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http

--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.0-wip
+## 2.3.0
 
 * Add the ability to abort requests.
 * Make `ConnectionException.toString` more helpful.

--- a/pkgs/cupertino_http/pubspec.yaml
+++ b/pkgs/cupertino_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cupertino_http
-version: 2.3.0-wip
+version: 2.3.0
 description: >-
   A macOS/iOS Flutter plugin that provides access to the Foundation URL
   Loading System.

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 1.5.0-beta.2
+## 1.5.0
 
 * Fixed a bug in `IOClient` where the `HttpClient`'s response stream was
   cancelled after the response stream was completed.
-
-## 1.5.0-beta
-
 * Added support for aborting requests before they complete.
 * Clarify that some header names may not be sent/received.
 

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 1.5.0-beta.2
+version: 1.5.0
 description: A composable, multi-platform, Future-based API for HTTP requests.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http
 


### PR DESCRIPTION
My plan is to release `package:http` and then `package:cronet_http` and `package:cupertino_http`.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
