### PR TITLE
Fix `fetch` response stream cancellation

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -3,6 +3,8 @@
 * **Breaking** Change the behavior of `Request.body` so that a charset
   parameter is only added for text and XML media types. This brings the
   behavior of `package:http` in line with RFC-8259.
+* On the web, fix cancellations for `StreamSubscription`s of response bodies
+  waiting for the next chunk.
 
 ## 1.5.0
 

--- a/pkgs/http/lib/src/browser_client.dart
+++ b/pkgs/http/lib/src/browser_client.dart
@@ -239,8 +239,7 @@ extension<T> on Stream<T> {
   Stream<T> doOnCancel(void Function() onCancel) => Stream.multi((listener) {
         // Note: We can't use listener.addStream because cancelling the listener
         // in that state would first await cancelling the upstream subscription,
-        // which is what we're trying to avoid here because we need to cancel
-        // the controller as soon as we receive the cancellation request.
+        // but we want to invoke onCancel first.
         var subscription = listen(listener.addSync,
             onError: listener.addErrorSync, onDone: listener.closeSync);
         listener

--- a/pkgs/http_client_conformance_tests/lib/src/response_body_streamed_server.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/response_body_streamed_server.dart
@@ -23,15 +23,26 @@ void hybridMain(StreamChannel<Object?> channel) async {
   late HttpServer server;
   server = (await HttpServer.bind('localhost', 0))
     ..listen((request) async {
+      var path = request.uri.pathSegments;
+      // Slow down lines if requested, e.g. GET /1000 would send a line every
+      // second. This is used to test cancellations.
+      var delayBetweenLines = switch (path) {
+        [var delayMs] => Duration(milliseconds: int.parse(delayMs)),
+        _ => Duration.zero,
+      };
+
       await request.drain<void>();
       request.response.headers.set('Access-Control-Allow-Origin', '*');
       request.response.headers.set('Content-Type', 'text/plain');
+      if (delayBetweenLines > Duration.zero) {
+        request.response.bufferOutput = false;
+      }
       serverWriting = true;
       for (var i = 0; serverWriting; ++i) {
         request.response.write('$i\n');
         await request.response.flush();
         // Let the event loop run.
-        await Future(() {});
+        await Future<void>.delayed(delayBetweenLines);
       }
       await request.response.close();
       unawaited(server.close());

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   async: ^2.8.2
   dart_style: ">=2.3.7 <4.0.0"
-  http: ^1.5.0
+  http: ^1.2.0
   stream_channel: ^2.1.1
   test: ^1.21.2
 

--- a/pkgs/http_client_conformance_tests/pubspec.yaml
+++ b/pkgs/http_client_conformance_tests/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   async: ^2.8.2
   dart_style: ">=2.3.7 <4.0.0"
-  http: ^1.2.0
+  http: ^1.5.0
   stream_channel: ^2.1.1
   test: ^1.21.2
 


### PR DESCRIPTION
The `fetch` client turns a `ReadableStreamDefaultReader` into a Dart `Stream` by repeatedly invoking `reader.read()` in an `async*` function.

This generally works well, but a problem with `async*` functions is that they can only respect cancellations when yielding. This results in cancellations taking longer than they need to in the following case:

1. A chunk of data is reported from the reader.
2. This is emitted by the stream, and we go into the next iteration of the `_readBody` loop.
3. Asynchronously, the listener calls `.cancel()` on its subscription.
4. This now has to wait for the next chunk of the source stream instead of aborting the request.

Since we already have an `AbortController` set up, this fixes the issue by adding an `onCancel` callback to abort the `fetch` request when the stream subscription is cancelled.

Closes https://github.com/dart-lang/http/issues/1820.

cc @brianquinlan 

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
