### PR TITLE
Remove documentation about WebSocketChannel constructor in doc comment

### DIFF
--- a/pkgs/web_socket_channel/CHANGELOG.md
+++ b/pkgs/web_socket_channel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.4
+
+- Remove obsolete documentation for `WebSocketChannel.new`.
+
 ## 3.0.3
 
 - Support `package:web_socket` 1.0.0.

--- a/pkgs/web_socket_channel/lib/src/channel.dart
+++ b/pkgs/web_socket_channel/lib/src/channel.dart
@@ -17,8 +17,6 @@ const String _webSocketGUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
 /// A [StreamChannel] that communicates over a WebSocket.
 ///
 /// This is implemented by classes that use `dart:io` and `dart:html`.
-/// The [WebSocketChannel.new] constructor can also be used on any platform to
-/// connect to use the WebSocket protocol over a pre-existing channel.
 ///
 /// All implementations emit [WebSocketChannelException]s. These exceptions wrap
 /// the native exception types where possible.

--- a/pkgs/web_socket_channel/pubspec.yaml
+++ b/pkgs/web_socket_channel/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 3.0.3
+version: 3.0.4
 description: >-
   A WebSocket API that enables cross-platform communication via StreamChannel.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/web_socket_channel


### PR DESCRIPTION
The constructor was removed in 3.0.0 according to the changelog, but the doc comment was not updated.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
