### PR TITLE
[cronet_http] Upgrade `cronet-embedded` dependency version to support 16 KB page sizes

### DIFF
--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -70,7 +70,7 @@ jobs:
           # the tests that rely on Google Play services with the newest API
           # level (34 as of March 2025). The tests that don't rely on Google
           # Play serviecs can test the oldest supported API level.
-          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '21' || '29' }} 
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '23' || '29' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -55,7 +55,7 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: Run tests
+      - name: Run tests (${{ matrix.cronetHttpNoPlay == 'true' && 'without Google Play' || 'with Google Play'}})
         uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed
         if: always() && steps.install.outcome == 'success'
         with:

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   verify:
-    name: Format & Analyze & Test
+    name: Format & Analyze & Test (${{ matrix.cronetHttpNoPlay == 'true' && 'without Google Play' || 'with Google Play'}})
     runs-on: ubuntu-cpu16-ram64
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -70,7 +70,7 @@ jobs:
           # the tests that rely on Google Play services with the newest API
           # level (34 as of March 2025). The tests that don't rely on Google
           # Play serviecs can test the oldest supported API level.
-          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '23' || '29' }} 
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '29' || '29' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/.github/workflows/cronet.yml
+++ b/.github/workflows/cronet.yml
@@ -70,7 +70,7 @@ jobs:
           # the tests that rely on Google Play services with the newest API
           # level (34 as of March 2025). The tests that don't rely on Google
           # Play serviecs can test the oldest supported API level.
-          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '29' || '29' }} 
+          api-level: ${{ matrix.cronetHttpNoPlay == 'true' && '24' || '29' }} 
           disable-animations: true
           arch: x86_64
           target: ${{ matrix.cronetHttpNoPlay == 'true' && 'default' || 'google_apis' }}

--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.1-wip
+## 1.6.0-wip
 
 * Upgrade `cronet-embedded` dependency version to support 16 KB page sizes.
 

--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0-wip
+
+* Upgrade `cronet-embedded` dependency version to support 16 KB page sizes.
+
 ## 1.5.0
 
 * Add the ability to abort requests.

--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.6.0-wip
 
-* Upgrade `cronet-embedded` dependency version to support 16 KB page sizes.
-  This forces the minimum Android SDK version to 23.
+* Upgrade the `cronet-embedded` dependency to `141.7340` version to
+  support 16 KB page sizes. `cronet-embedded` has target SDK version of 24.
+* Change the minimum SDK version to 24.
 
 ## 1.5.0
 

--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.0-wip
+## 1.5.1-wip
 
 * Upgrade `cronet-embedded` dependency version to support 16 KB page sizes.
 

--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.6.0-wip
 
 * Upgrade `cronet-embedded` dependency version to support 16 KB page sizes.
+  This forces the minimum Android SDK version to 23.
 
 ## 1.5.0
 

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -48,7 +48,7 @@ android {
         // - .github/workflows/cronet.yml
         // - pkgs/cronet_http/android/build.gradle
         // - pkgs/cronet_http/example/android/app/build.gradle
-        minSdkVersion 21
+        minSdkVersion 23
     }
 
     defaultConfig {

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -64,7 +64,7 @@ android {
 
 dependencies {
     if (dartDefines.cronetHttpNoPlay == 'true') {
-        implementation 'org.chromium.net:cronet-embedded:119.6045.31'
+        implementation 'org.chromium.net:cronet-embedded:141.7340.3'
     } else {
         implementation "com.google.android.gms:play-services-cronet:18.1.0"
     }

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -48,7 +48,7 @@ android {
         // - .github/workflows/cronet.yml
         // - pkgs/cronet_http/android/build.gradle
         // - pkgs/cronet_http/example/android/app/build.gradle
-        minSdkVersion 23
+        minSdkVersion 24
     }
 
     defaultConfig {

--- a/pkgs/cronet_http/example/android/app/build.gradle
+++ b/pkgs/cronet_http/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
         // - .github/workflows/cronet.yml
         // - pkgs/cronet_http/android/build.gradle
         // - pkgs/cronet_http/example/android/app/build.gradle
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pkgs/cronet_http/example/android/app/build.gradle
+++ b/pkgs/cronet_http/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
         // - .github/workflows/cronet.yml
         // - pkgs/cronet_http/android/build.gradle
         // - pkgs/cronet_http/example/android/app/build.gradle
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cronet_http
-version: 1.5.0
+version: 1.5.1-wip
 description: >-
   An Android Flutter plugin that provides access to the Cronet HTTP client.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http

--- a/pkgs/cronet_http/pubspec.yaml
+++ b/pkgs/cronet_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cronet_http
-version: 1.5.1-wip
+version: 1.6.0-wip
 description: >-
   An Android Flutter plugin that provides access to the Cronet HTTP client.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/cronet_http


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1801

Since https://issues.chromium.org/issues/337191293 was resolved, we now have a working version that supports 16 KB page sizes. This PR upgrades to targeting that version.