### PR TITLE
fix 1825: wrap decoding in try/catch

### DIFF
--- a/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_web_socket.dart
@@ -203,7 +203,13 @@ class CupertinoWebSocket implements WebSocket {
 
   void _connectionClosed(int? closeCode, objc.NSData? reason) {
     if (!_events.isClosed) {
-      final closeReason = reason == null ? '' : utf8.decode(reason.toList());
+      String closeReason;
+
+      try {
+        closeReason = reason == null ? '' : utf8.decode(reason.toList());
+      } on FormatException {
+        closeReason = 'unknown';
+      }
 
       _events
         ..add(CloseReceived(closeCode, closeReason))


### PR DESCRIPTION
This PR wraps the utf8 decoding of a connection close reason in a try/catch block, defaulting to the 'unknown' string.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
