### PR TITLE
fix(ok_http): trust manager init

### DIFF
--- a/pkgs/ok_http/lib/src/ok_http_client.dart
+++ b/pkgs/ok_http/lib/src/ok_http_client.dart
@@ -260,9 +260,10 @@ class OkHttpClient extends BaseClient {
       if (!configuration.validateServerCertificates) {
         trustManagers[0] = _allAllTrustManager;
       } else {
-        final tms = bindings.TrustManagerFactory.getInstance(
-                bindings.TrustManagerFactory.getDefaultAlgorithm())!
-            .getTrustManagers()!;
+        final tmf = bindings.TrustManagerFactory.getInstance(
+            bindings.TrustManagerFactory.getDefaultAlgorithm())!
+          ..init(null);
+        final tms = tmf.getTrustManagers()!;
         if (tms.length != 1) {
           throw StateError('unexpected XXX');
         }


### PR DESCRIPTION
- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

---

Due to an issue with the client implementation, the code never worked and caused an exception:

```
I/flutter (20540): java.lang.IllegalStateException: TrustManagerFactory not initialized
I/flutter (20540): 	at android.security.net.config.RootTrustManagerFactorySpi.engineGetTrustManagers(RootTrustManagerFactorySpi.java:63)
I/flutter (20540): 	at javax.net.ssl.TrustManagerFactory.getTrustManagers(TrustManagerFactory.java:301)
I/flutter (20540): 	at android.os.MessageQueue.nativePollOnce(Native Method)
I/flutter (20540): 	at android.os.MessageQueue.next(MessageQueue.java:370)
I/flutter (20540): 	at android.os.Looper.loopOnce(Looper.java:214)
I/flutter (20540): 	at android.os.Looper.loop(Looper.java:393)
I/flutter (20540): 	at android.app.ActivityThread.main(ActivityThread.java:9564)
I/flutter (20540): 	at java.lang.reflect.Method.invoke(Native Method)
I/flutter (20540): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
I/flutter (20540): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1010)
```


By adding`.init(null)`, the problem disappears and the library works as expected.