### PR TITLE
chore(cronet_http): bump compileSdkVersion to 34

### DIFF
--- a/pkgs/cronet_http/CHANGELOG.md
+++ b/pkgs/cronet_http/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Upgrade the `cronet-embedded` dependency to `141.7340` version to
   support 16 KB page sizes. `cronet-embedded` has target SDK version of 24.
 * Change the minimum SDK version to 24.
+* Change the compilie SDK version to 34 for compatibility with AGP 8.13.
 
 ## 1.5.0
 
@@ -71,7 +72,7 @@
 
 ## 1.0.0
 
-* No functional changes. 
+* No functional changes.
 
 ## 0.4.2
 
@@ -79,14 +80,14 @@
 * Fix a bug where incorrect HTTP request methods were sent.
 
 ## 0.4.1
- 
-* Require `package:jni >= 0.7.1` so that depending on `package:cronet_http` 
+
+* Require `package:jni >= 0.7.1` so that depending on `package:cronet_http`
   does not break macOS builds.
 
 * Fix obsolete `CronetClient()` constructor usage.
 
 ## 0.4.0
- 
+
 * Use more efficient operations when copying bytes between Java and Dart.
 
 ## 0.3.0-jni
@@ -140,7 +141,7 @@
 
 ## 0.0.2
 
-* Set `StreamedResponse.reasonPhrase` and `StreamedResponse.request`. 
+* Set `StreamedResponse.reasonPhrase` and `StreamedResponse.request`.
 
 ## 0.0.1
 

--- a/pkgs/cronet_http/android/build.gradle
+++ b/pkgs/cronet_http/android/build.gradle
@@ -28,7 +28,7 @@ android {
         namespace 'io.flutter.plugins.cronet_http'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11


### PR DESCRIPTION
Bump the `compileSdkVersion` to 34 to be compatible with AGP 8.13.
Fixes #1821

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
