### PR TITLE
fix(http_multi_server): Replace expired test certificates

### DIFF
--- a/pkgs/http_multi_server/test/http_multi_server_test.dart
+++ b/pkgs/http_multi_server/test/http_multi_server_test.dart
@@ -323,6 +323,20 @@ Future<String> _read(HttpServer server) => http.read(_urlFor(server));
 Uri _urlFor(HttpServer server) =>
     Uri.http('${server.address.host}:${server.port}', '/');
 
+// The certificates were taken from the Dart SDK at
+// `_sslCert`: tests/standalone/io/certificates/untrusted_server_chain.pem
+// `_sslKey`: tests/standalone/io/certificates/untrusted_server_key.pem
+//
+// I tried to recreate these certificates using a modified version of the script
+// at tests/standalone/io/create_sample_certificates.sh but the
+// "PBE-SHA1-RC4-128" algorithm is no longer supported by openssl and replacing
+// it with "aes-256-cbc" causes the tests to fail with:
+//
+// HandshakeException: Handshake error in client (OS Error:
+// CERTIFICATE_VERIFY_FAILED:
+//                       ... application verification failure(handshake.cc:297))
+//
+// The current certificates will expire in 2030.
 final _sslCert = utf8.encode('''
 -----BEGIN CERTIFICATE-----
 MIIDZDCCAkygAwIBAgIBATANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVpbnRl


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1839

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
