### PR TITLE
Replace pub run with dart run

### DIFF
--- a/pkgs/cupertino_http/ffigen.yaml
+++ b/pkgs/cupertino_http/ffigen.yaml
@@ -1,9 +1,9 @@
-# Run with `flutter packages pub run ffigen --config ffigen.yaml`.
+# Run with `dart run ffigen --config ffigen.yaml`.
 name: NativeCupertinoHttp
 description: |
   Bindings for the Foundation URL Loading System and supporting libraries.
 
-  Regenerate bindings with `flutter packages pub run ffigen --config ffigen.yaml`.
+  Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
 language: 'objc'
 output:
   bindings: 'lib/src/native_cupertino_bindings.dart'


### PR DESCRIPTION
Following up on https://github.com/dart-lang/pub/issues/4737, this PR replaces deprecated `pub run` commands with `dart run`.