### PR TITLE
feat: add isOk convenience getter to BaseResponse

### DIFF
--- a/pkgs/http/lib/src/base_response.dart
+++ b/pkgs/http/lib/src/base_response.dart
@@ -84,6 +84,9 @@ abstract class BaseResponse {
       throw ArgumentError('Invalid content length $contentLength.');
     }
   }
+
+  /// Whether the status code is 200 (OK).
+  bool get isOk => statusCode == 200;
 }
 
 /// A [BaseResponse] with a [url] field.

--- a/pkgs/http/lib/src/response.dart
+++ b/pkgs/http/lib/src/response.dart
@@ -64,9 +64,6 @@ class Response extends BaseResponse {
         persistentConnection: response.persistentConnection,
         reasonPhrase: response.reasonPhrase);
   }
-
-  /// Returns true if the status code is 200 (OK).
-  bool get isOk => statusCode == 200;
 }
 
 /// Returns the encoding to use for a response with the given headers.

--- a/pkgs/http/test/response_test.dart
+++ b/pkgs/http/test/response_test.dart
@@ -184,25 +184,43 @@ void main() {
     });
   });
 
-  group('Response getters', () {
-    test('returns true for status code 200', () {
-      final response = http.Response('', 200);
-      expect(response.isOk, isTrue);
-    });
+  group('BaseResponse getters', () {
+    group('isOk', () {
+      group('Response', () {
+        test('returns true for status code 200', () {
+          final response = http.Response('', 200);
+          expect(response.isOk, isTrue);
+        });
 
-    test('returns false for status code 201', () {
-      final response = http.Response('', 201);
-      expect(response.isOk, isFalse);
-    });
+        test('returns false for status code 201', () {
+          final response = http.Response('', 201);
+          expect(response.isOk, isFalse);
+        });
 
-    test('returns false for status code 404', () {
-      final response = http.Response('', 404);
-      expect(response.isOk, isFalse);
-    });
+        test('returns false for status code 404', () {
+          final response = http.Response('', 404);
+          expect(response.isOk, isFalse);
+        });
 
-    test('returns false for status code 500', () {
-      final response = http.Response('', 500);
-      expect(response.isOk, isFalse);
+        test('returns false for status code 500', () {
+          final response = http.Response('', 500);
+          expect(response.isOk, isFalse);
+        });
+      });
+
+      group('StreamedResponse', () {
+        test('returns true for status code 200', () {
+          final response =
+          http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+          expect(response.isOk, isTrue);
+        });
+
+        test('returns false for status code 404', () {
+          final response =
+          http.StreamedResponse(const Stream<List<int>>.empty(), 404);
+          expect(response.isOk, isFalse);
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
This PR adds a convenience getter isOk to the BaseResponse class.

What is changing? I have added a boolean getter isOk to BaseResponse that returns true if the statusCode is exactly 200. By placing it in the base class, this convenience is now available for all response types, including Response and StreamedResponse.
I have also added unit tests to verify this behavior across both response types and various status codes (200, 201, 404, 500).

Why? Checking for a 200 OK response is the most frequent operation when handling HTTP requests. Currently, developers must either:

1. Use magic numbers (e.g., if (response.statusCode == 200)), which is less expressive.
2. Import dart:io to use HttpStatus.ok (e.g., if (response.statusCode == HttpStatus.ok)).

This addition makes the API more intuitive and readable while remaining platform-agnostic:

```
final response = await http.get(url);
if (response.isOk) {
  // Handle success
}
```

•
[x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
<details> <summary>Contribution guidelines:</summary><br>
•
See our contributor guide for general expectations for PRs.
•
Larger or significant changes should be discussed in an issue before creating a PR.
•
Contributions to our repos should follow the Dart style guide and use dart format.
•
Most changes should add an entry to the changelog and may need to rev the pubspec package version.
•
Changes to packages require corresponding tests.
Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.