### PR TITLE
docs(cupertino): remove BREAKING for SDK requires

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 * **BREAKING CHANGE:** Remove `shouldUseExtendedBackgroundIdleMode` from
   `URLSessionConfiguration`.
-* **BREAKING CHANGE:** Require Dart 3.10+.
+* **BREAKING:** Update minimum supported versions to iOS 15
+  (released on September 20, 2022) and macOS 12 (released October 25, 2021).
+* Require Dart 3.10+.
 * Support usage in Dart SDK projects.
 * Fix a bug where close reasons not containing valid UTF-8 would cause an
   uncatchable exception to be thrown.
 * Exclude unnecessary generated code. Slightly reduces disk space requirements.
 * Add `URLSessionTask.taskDelegate` setter and `URLSessionTask.delegate`
   builder to enable use of task-level delegates.
-* **BREAKING:** Update minimum supported versions to iOS 15
-  (released on September 20, 2022) and macOS 12 (released October 25, 2021).
 
 ## 2.4.0
 


### PR DESCRIPTION
The SDK constraint is captured in pubspec.yaml so it cannot break existing code. Also moves the breaking changes to the top of the CHANGELOG.md

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
