### PR TITLE
feat: Add parseAcceptHeader, prepare v4.20

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   health:
     # REVERT ME! This is just for testing!
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@firehose_sync_silly
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@bbd081438368066a290ec6ec2e9a0506ae30b1c1
     with:
       sdk: dev
       channel: dev

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   health:
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    # REVERT ME! This is just for testing!
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@firehose_sync_silly
     with:
       sdk: dev
       channel: dev

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -7,10 +7,15 @@ on:
 jobs:
   health:
     # REVERT ME! This is just for testing!
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@bbd081438368066a290ec6ec2e9a0506ae30b1c1
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@firehose_sync_silly
     with:
       sdk: dev
       channel: dev
       flutter_packages: "pkgs/cronet_http,pkgs/cupertino_http,pkgs/ok_http"
+
+      # REVERT ME! This is just for testing!
+      firehose-repository: dart-lang/ecosystem
+      firehose-ref: firehose_sync_silly
+
     permissions:
       pull-requests: write

--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   health:
     # REVERT ME! This is just for testing!
-    uses: dart-lang/ecosystem/.github/workflows/health.yaml@firehose_sync_silly
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@cleanup_fun
     with:
       sdk: dev
       channel: dev
@@ -15,7 +15,7 @@ jobs:
 
       # REVERT ME! This is just for testing!
       firehose-repository: dart-lang/ecosystem
-      firehose-ref: firehose_sync_silly
+      firehose-ref: cleanup_fun
 
     permissions:
       pull-requests: write

--- a/pkgs/http_parser/CHANGELOG.md
+++ b/pkgs/http_parser/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.2.0
+
+* Add `parseAcceptHeader`: parse an Accept header and return a list of
+  `MediaType` objects sorted by preference.
+
 ## 4.1.2
 
 * Fixed a bug where parsing quoted header values could require a regex to

--- a/pkgs/http_parser/lib/http_parser.dart
+++ b/pkgs/http_parser/lib/http_parser.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+export 'src/accept_header.dart';
 export 'src/authentication_challenge.dart';
 export 'src/case_insensitive_map.dart';
 export 'src/chunked_coding.dart';
 export 'src/http_date.dart';
-export 'src/media_type.dart';
+export 'src/media_type.dart' hide parseFromScanner;

--- a/pkgs/http_parser/lib/src/accept_header.dart
+++ b/pkgs/http_parser/lib/src/accept_header.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:string_scanner/string_scanner.dart';
+import 'media_type.dart';
+import 'scan.dart';
+import 'utils.dart';
+
+/// Parses an HTTP Accept header.
+///
+/// Returns a list of [MediaType] objects sorted by preference.
+/// Preference is determined by:
+/// 1. Quality factor `q` (higher is better).
+/// 2. Specificity (more specific is better).
+/// 3. Number of parameters (more is better).
+List<MediaType> parseAcceptHeader(String headerValue) {
+  if (headerValue.isEmpty) return [];
+
+  return wrapFormatException('Accept header', headerValue, () {
+    final scanner = StringScanner(headerValue);
+    final mediaTypes = parseList(scanner, () => parseFromScanner(scanner));
+    scanner.expectDone();
+
+    // Sort by preference
+    mediaTypes.sort((a, b) {
+      final qA = double.tryParse(a.parameters['q'] ?? '1.0') ?? 1.0;
+      final qB = double.tryParse(b.parameters['q'] ?? '1.0') ?? 1.0;
+
+      if (qA != qB) {
+        return qB.compareTo(qA); // Higher q first
+      }
+
+      // Specificity
+      // type/subtype > type/* > */*
+      final specificityA = _getSpecificity(a);
+      final specificityB = _getSpecificity(b);
+
+      if (specificityA != specificityB) {
+        return specificityB.compareTo(specificityA); // More specific first
+      }
+
+      // If still equal, number of parameters (excluding q)
+      final paramsA = a.parameters.keys.where((k) => k != 'q').length;
+      final paramsB = b.parameters.keys.where((k) => k != 'q').length;
+      return paramsB.compareTo(paramsA); // More parameters first
+    });
+
+    return mediaTypes;
+  });
+}
+
+int _getSpecificity(MediaType mediaType) {
+  if (mediaType.type == '*') return 0;
+  if (mediaType.subtype == '*') return 1;
+  return 2;
+}

--- a/pkgs/http_parser/lib/src/media_type.dart
+++ b/pkgs/http_parser/lib/src/media_type.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
 import 'package:string_scanner/string_scanner.dart';
 
 import 'case_insensitive_map.dart';
@@ -41,38 +42,11 @@ class MediaType {
   ///
   /// This will throw a FormatError if the media type is invalid.
   factory MediaType.parse(String mediaType) =>
-      // This parsing is based on sections 3.6 and 3.7 of the HTTP spec:
-      // http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html.
       wrapFormatException('media type', mediaType, () {
         final scanner = StringScanner(mediaType);
-        scanner.scan(whitespace);
-        scanner.expect(token);
-        final type = scanner.lastMatch![0]!;
-        scanner.expect('/');
-        scanner.expect(token);
-        final subtype = scanner.lastMatch![0]!;
-        scanner.scan(whitespace);
-
-        final parameters = <String, String>{};
-        while (scanner.scan(';')) {
-          scanner.scan(whitespace);
-          scanner.expect(token);
-          final attribute = scanner.lastMatch![0]!;
-          scanner.expect('=');
-
-          String value;
-          if (scanner.scan(token)) {
-            value = scanner.lastMatch![0]!;
-          } else {
-            value = expectQuotedString(scanner);
-          }
-
-          scanner.scan(whitespace);
-          parameters[attribute] = value;
-        }
-
+        final result = parseFromScanner(scanner);
         scanner.expectDone();
-        return MediaType(type, subtype, parameters);
+        return result;
       });
 
   MediaType(String type, String subtype, [Map<String, String>? parameters])
@@ -151,4 +125,39 @@ class MediaType {
 
     return buffer.toString();
   }
+}
+
+/// Parses a media type from [scanner].
+///
+/// This is based on sections 3.6 and 3.7 of the HTTP spec:
+/// http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html.
+@internal
+MediaType parseFromScanner(StringScanner scanner) {
+  scanner.scan(whitespace);
+  scanner.expect(token);
+  final type = scanner.lastMatch![0]!;
+  scanner.expect('/');
+  scanner.expect(token);
+  final subtype = scanner.lastMatch![0]!;
+  scanner.scan(whitespace);
+
+  final parameters = <String, String>{};
+  while (scanner.scan(';')) {
+    scanner.scan(whitespace);
+    scanner.expect(token);
+    final attribute = scanner.lastMatch![0]!;
+    scanner.expect('=');
+
+    String value;
+    if (scanner.scan(token)) {
+      value = scanner.lastMatch![0]!;
+    } else {
+      value = expectQuotedString(scanner);
+    }
+
+    scanner.scan(whitespace);
+    parameters[attribute] = value;
+  }
+
+  return MediaType(type, subtype, parameters);
 }

--- a/pkgs/http_parser/pubspec.yaml
+++ b/pkgs/http_parser/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_parser
-version: 4.1.2
+version: 4.2.0
 description: >-
   A platform-independent package for parsing and serializing HTTP formats.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http_parser
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.19.0
+  meta: ^1.3.0
   source_span: ^1.8.0
   string_scanner: ^1.1.0
   typed_data: ^1.3.0

--- a/pkgs/http_parser/test/accept_header_test.dart
+++ b/pkgs/http_parser/test/accept_header_test.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:http_parser/http_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parseAcceptHeader', () {
+    test('parses empty header', () {
+      expect(parseAcceptHeader(''), isEmpty);
+    });
+
+    test('parses simple header', () {
+      final result = parseAcceptHeader('text/html');
+      expect(result, hasLength(1));
+      expect(result[0].mimeType, equals('text/html'));
+    });
+
+    test('parses multiple media types', () {
+      final result = parseAcceptHeader('text/html, application/xhtml+xml');
+      expect(result, hasLength(2));
+      expect(result[0].mimeType, equals('text/html'));
+      expect(result[1].mimeType, equals('application/xhtml+xml'));
+    });
+
+    test('sorts by quality factor q', () {
+      final result =
+          parseAcceptHeader('text/html;q=0.5, application/xhtml+xml;q=0.9');
+      expect(result, hasLength(2));
+      expect(result[0].mimeType, equals('application/xhtml+xml'));
+      expect(result[1].mimeType, equals('text/html'));
+    });
+
+    test('sorts by specificity', () {
+      final result = parseAcceptHeader('*/*, text/*, text/html');
+      expect(result, hasLength(3));
+      expect(result[0].mimeType, equals('text/html'));
+      expect(result[1].mimeType, equals('text/*'));
+      expect(result[2].mimeType, equals('*/*'));
+    });
+
+    test('sorts by specificity with equal q', () {
+      final result =
+          parseAcceptHeader('*/*;q=0.9, text/*;q=0.9, text/html;q=0.9');
+      expect(result, hasLength(3));
+      expect(result[0].mimeType, equals('text/html'));
+      expect(result[1].mimeType, equals('text/*'));
+      expect(result[2].mimeType, equals('*/*'));
+    });
+
+    test('sorts by number of parameters with equal q and specificity', () {
+      final result = parseAcceptHeader('text/html;foo=bar, text/html');
+      expect(result, hasLength(2));
+      expect(result[0].parameters, containsPair('foo', 'bar'));
+      expect(result[1].parameters, isEmpty);
+    });
+
+    test('handles invalid media types gracefully (throws FormatError)', () {
+      expect(
+          () => parseAcceptHeader('invalid_media_type'), throwsFormatException);
+    });
+
+    test('handles empty elements (ignores them)', () {
+      final result = parseAcceptHeader('text/html,, application/xhtml+xml');
+      expect(result, hasLength(2));
+      expect(result[0].mimeType, equals('text/html'));
+      expect(result[1].mimeType, equals('application/xhtml+xml'));
+    });
+
+    test('handles whitespace around commas', () {
+      final result = parseAcceptHeader('text/html , application/xhtml+xml');
+      expect(result, hasLength(2));
+      expect(result[0].mimeType, equals('text/html'));
+      expect(result[1].mimeType, equals('application/xhtml+xml'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/http/issues/1904

- Add `parseAcceptHeader` to parse and sort Accept headers by preference.
- Move `MediaType.parseFromScanner` to a top-level `@internal` function to avoid API bloat.
- Hide `parseFromScanner` in the public export of `lib/http_parser.dart`.
- Update `CHANGELOG.md` and bump version to 4.2.0.
- Add dependency on `package:meta` for `@internal` annotation.
