### PR TITLE
feat(cupertino): throw on close with active requests

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 * **BREAKING CHANGE:** Remove `shouldUseExtendedBackgroundIdleMode` from
   `URLSessionConfiguration`.
-* **BREAKING CHANGE:** Require Dart 3.10+.
 * Support usage in Dart SDK projects.
 * Fix a bug where close reasons not containing valid UTF-8 would cause an
   uncatchable exception to be thrown.
@@ -12,6 +11,7 @@
 * **BREAKING:** Update minimum supported versions to iOS 15
   (released on September 20, 2022) and macOS 12 (released October 25, 2021).
 * Updated the example to not require Flutter.
+* Make `close` throw if there are pending requests when called.
 
 ## 2.4.0
 

--- a/pkgs/cupertino_http/lib/src/cupertino_client.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_client.dart
@@ -78,6 +78,16 @@ class _StreamedResponseWithUrl extends StreamedResponse
 /// }
 /// ```
 class CupertinoClient extends BaseClient {
+  /// A map of [URLSessionTask.taskIdentifier] to a [Completer] that will be
+  /// completed when the task's `onComplete` callback is invoked (i.e. the task
+  /// is complete and will no longer invoke callbacks).
+  ///
+  /// The [Completer.future] is `await`ed to ensure that there is no possibility
+  /// of further callbacks being invoked after:
+  /// - [send] throws (e.g. too many redirects).
+  /// - the response stream subscription is cancelled.
+  final _tasks = <int, Completer<void>>{};
+
   URLSession? _urlSession;
 
   CupertinoClient._(this._urlSession);
@@ -185,6 +195,9 @@ class CupertinoClient extends BaseClient {
 
   @override
   void close() {
+    if (_tasks.isNotEmpty) {
+      throw StateError('cannot close with running requests');
+    }
     _urlSession?.finishTasksAndInvalidate();
     _urlSession = null;
   }
@@ -293,9 +306,10 @@ class CupertinoClient extends BaseClient {
 
     final task = urlSession.dataTaskWithRequest(urlRequest);
     final dataController = StreamController<Uint8List>(
-      onCancel: () {
+      onCancel: () async {
         cancelled = true;
         task.cancel();
+        await _tasks[task.taskIdentifier]?.future;
       },
     );
 
@@ -329,6 +343,7 @@ class CupertinoClient extends BaseClient {
             unawaited(profile?.responseData.close());
           }
           dataController.close();
+          _tasks.remove(task.taskIdentifier)!.complete();
         },
         onRedirect: (session, task, response, request) {
           numRedirects += 1;
@@ -349,64 +364,70 @@ class CupertinoClient extends BaseClient {
         },
       )
       ..resume();
+    _tasks[task.taskIdentifier] = Completer<void>();
 
-    if (request case Abortable(:final abortTrigger?)) {
-      unawaited(
-        abortTrigger.whenComplete(() {
-          cancelled = true;
-          task.cancel();
-        }),
-      );
-    }
-
-    final URLResponse urlResponse;
     try {
-      urlResponse = await responseCompleter.future;
-    } finally {
-      // If the request is aborted before the `NSUrlSessionTask` opens the
-      // `NSInputStream` attached to `NSMutableURLRequest.HTTPBodyStream`, then
-      // the task will not close the `NSInputStream`.
-      //
-      // This will cause the Dart portion of the `NSInputStream` implementation
-      // to hang waiting for a close message.
-      //
-      // See https://github.com/dart-lang/native/issues/2333
-      if (nsStream?.streamStatus != NSStreamStatus.NSStreamStatusClosed) {
-        nsStream?.close();
+      if (request case Abortable(:final abortTrigger?)) {
+        unawaited(
+          abortTrigger.whenComplete(() {
+            cancelled = true;
+            task.cancel();
+          }),
+        );
       }
+
+      final URLResponse urlResponse;
+      try {
+        urlResponse = await responseCompleter.future;
+      } finally {
+        // If the request is aborted before the `NSUrlSessionTask` opens the
+        // `NSInputStream` attached to `NSMutableURLRequest.HTTPBodyStream`, then
+        // the task will not close the `NSInputStream`.
+        //
+        // This will cause the Dart portion of the `NSInputStream` implementation
+        // to hang waiting for a close message.
+        //
+        // See https://github.com/dart-lang/native/issues/2333
+        if (nsStream?.streamStatus != NSStreamStatus.NSStreamStatusClosed) {
+          nsStream?.close();
+        }
+      }
+      unawaited(profile?.requestData.close());
+
+      final response = urlResponse as HTTPURLResponse;
+      if (request.followRedirects && numRedirects > request.maxRedirects) {
+        throw ClientException('Redirect limit exceeded', request.url);
+      }
+
+      final responseHeaders = _getResponseHeaders(response, request);
+      final contentLength = response.expectedContentLength == -1
+          ? null
+          : response.expectedContentLength;
+      final isRedirect = !request.followRedirects && numRedirects > 0;
+      final reasonPhrase = _findReasonPhrase(response.statusCode);
+
+      profile?.responseData
+        ?..contentLength = contentLength
+        ..headersCommaValues = responseHeaders
+        ..isRedirect = isRedirect
+        ..reasonPhrase = reasonPhrase
+        ..startTime = DateTime.now()
+        ..statusCode = response.statusCode;
+
+      return _StreamedResponseWithUrl(
+        dataController.stream,
+        response.statusCode,
+        url: lastRedirectUrl ?? request.url,
+        contentLength: contentLength,
+        reasonPhrase: reasonPhrase,
+        request: request,
+        isRedirect: isRedirect,
+        headers: responseHeaders,
+      );
+    } catch (e) {
+      await _tasks[task.taskIdentifier]?.future;
+      rethrow;
     }
-    unawaited(profile?.requestData.close());
-
-    final response = urlResponse as HTTPURLResponse;
-    if (request.followRedirects && numRedirects > request.maxRedirects) {
-      throw ClientException('Redirect limit exceeded', request.url);
-    }
-
-    final responseHeaders = _getResponseHeaders(response, request);
-    final contentLength = response.expectedContentLength == -1
-        ? null
-        : response.expectedContentLength;
-    final isRedirect = !request.followRedirects && numRedirects > 0;
-    final reasonPhrase = _findReasonPhrase(response.statusCode);
-
-    profile?.responseData
-      ?..contentLength = contentLength
-      ..headersCommaValues = responseHeaders
-      ..isRedirect = isRedirect
-      ..reasonPhrase = reasonPhrase
-      ..startTime = DateTime.now()
-      ..statusCode = response.statusCode;
-
-    return _StreamedResponseWithUrl(
-      dataController.stream,
-      response.statusCode,
-      url: lastRedirectUrl ?? request.url,
-      contentLength: contentLength,
-      reasonPhrase: reasonPhrase,
-      request: request,
-      isRedirect: isRedirect,
-      headers: responseHeaders,
-    );
   }
 
   Map<String, String> _getResponseHeaders(

--- a/pkgs/cupertino_http/lib/src/cupertino_client.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_client.dart
@@ -381,11 +381,11 @@ class CupertinoClient extends BaseClient {
         urlResponse = await responseCompleter.future;
       } finally {
         // If the request is aborted before the `NSUrlSessionTask` opens the
-        // `NSInputStream` attached to `NSMutableURLRequest.HTTPBodyStream`, then
-        // the task will not close the `NSInputStream`.
+        // `NSInputStream` attached to `NSMutableURLRequest.HTTPBodyStream`,
+        // then the task will not close the `NSInputStream`.
         //
-        // This will cause the Dart portion of the `NSInputStream` implementation
-        // to hang waiting for a close message.
+        // This will cause the Dart portion of the `NSInputStream`
+        // implementation to hang waiting for a close message.
         //
         // See https://github.com/dart-lang/native/issues/2333
         if (nsStream?.streamStatus != NSStreamStatus.NSStreamStatusClosed) {

--- a/pkgs/cupertino_http/lib/src/cupertino_client.dart
+++ b/pkgs/cupertino_http/lib/src/cupertino_client.dart
@@ -399,7 +399,7 @@ class CupertinoClient extends BaseClient {
         throw ClientException('Redirect limit exceeded', request.url);
       }
 
-      final responseHeaders = _getResponseHeaders(response, request);
+      final responseHeaders = _responseHeaders(response, request);
       final contentLength = response.expectedContentLength == -1
           ? null
           : response.expectedContentLength;
@@ -430,7 +430,7 @@ class CupertinoClient extends BaseClient {
     }
   }
 
-  Map<String, String> _getResponseHeaders(
+  Map<String, String> _responseHeaders(
     HTTPURLResponse response,
     BaseRequest request,
   ) {

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.6.1-wip
 
 * Clarified the behavior of response headers in API documentation comments.
+* Make it more clear that `close` must be called for correctness.
 
 ## 1.6.0
 

--- a/pkgs/http/lib/src/client.dart
+++ b/pkgs/http/lib/src/client.dart
@@ -148,15 +148,13 @@ abstract interface class Client {
 
   /// Closes the client and cleans up any resources associated with it.
   ///
-  /// Some clients maintain a pool of network connections that will not be
-  /// disconnected until the client is closed. This may cause programs using
-  /// using the Dart SDK (`dart run`, `dart test`, `dart compile`, etc.) to
-  /// not terminate until the client is closed. Programs run using the Flutter
-  /// SDK can still terminate even with an active connection pool.
-  ///
-  /// Once [close] is called, no other methods should be called. If [close] is
-  /// called while other asynchronous methods are running, the behavior is
+  /// Once [close] is called, no other [Client] methods should be called. If
+  /// [close] is called while there are active requests, the behavior is
   /// undefined.
+  ///
+  /// > [!WARNING]
+  /// > The behavior is undefined if [close] is not called before the isolate
+  /// > that created this [Client], including the main isolate, exits.
   void close();
 }
 

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -230,13 +230,6 @@ class IOClient extends BaseClient {
     }
   }
 
-  /// Closes the client.
-  ///
-  /// Terminates all active connections. If a client remains unclosed, the Dart
-  /// process may not terminate.
-  ///
-  /// The behavior of `close` is not defined if there are requests executing
-  /// when `close` is called.
   @override
   void close() {
     if (_inner != null) {

--- a/pkgs/http_client_conformance_tests/lib/src/response_body_streamed_test.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/response_body_streamed_test.dart
@@ -188,7 +188,7 @@ void testResponseBodyStreamed(Client Function() clientFactory,
           .listen((s) async {
         final lastReceived = int.parse(s.trim());
         if (lastReceived == 1000) {
-          unawaited(subscription.cancel());
+          await subscription.cancel();
           cancelled.complete();
         }
       });


### PR DESCRIPTION
Makes https://github.com/dart-lang/http/issues/1894 more diagnosable by changing `CupertinoClient.close` to throw if there are pending requests. So long as the developer remembers to call `close` before the isolate exists, they will be warned (through the exception) that they did not wait for all of requests to complete.

Also makes it more clear that `Client.close` **must** be called.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
