### PR TITLE
Preserve header case in `IOClient`

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Clarified the behavior of response headers in API documentation comments.
 * Replace references to `dart:web` with `package:web` dartdoc.
+* Preserve header cases in `IOClient`.
 
 ## 1.6.0
 

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -117,7 +117,7 @@ class IOClient extends BaseClient {
         ..contentLength = (request.contentLength ?? -1)
         ..persistentConnection = request.persistentConnection;
       request.headers.forEach((name, value) {
-        ioRequest.headers.set(name, value);
+        ioRequest.headers.set(name, value, preserveHeaderCase: true);
       });
 
       // SDK request aborting is only effective up until the request is closed,

--- a/pkgs/http/test/io/client_test.dart
+++ b/pkgs/http/test/io/client_test.dart
@@ -8,6 +8,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:http/io_client.dart' as http_io;
@@ -184,5 +185,45 @@ void main() {
     http.runWithClient(() {
       http.runWithClient(http.Client.new, http.Client.new);
     }, http.Client.new);
+  });
+
+  test('preserves header case', () async {
+    // Avoid `HttpServer` header normalization with a direct socket server.
+    final server = await ServerSocket.bind('localhost', 0);
+    final url = Uri.http('localhost:${server.port}', '');
+
+    final client = http.Client();
+    final request = http.Request('POST', url)
+      ..headers['X-Custom-Header'] = 'value';
+
+    final responseFuture = client.send(request);
+
+    final socket = await server.first;
+    final bytes = BytesBuilder();
+    const needle = [13, 10, 13, 10];
+    var needleIndex = 0;
+
+    collectHeader:
+    await for (var data in socket) {
+      bytes.add(data);
+      for (final byte in data) {
+        if (byte == needle[needleIndex]) {
+          if (++needleIndex == 4) break collectHeader;
+        } else {
+          needleIndex = (byte == 13) ? 1 : 0;
+        }
+      }
+    }
+
+    expect(utf8.decode(bytes.toBytes()), contains('X-Custom-Header: value'));
+
+    socket.write('HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n');
+    await socket.flush();
+    await socket.close();
+    await server.close();
+
+    final response = await responseFuture;
+    expect(response.statusCode, equals(200));
+    client.close();
   });
 }


### PR DESCRIPTION
Closes #609

Some non-compliant servers misbehave with the default handling of
headers in the `dart:io` HTTP implementation. Well behaved servers
should not be impacted, but other use cases which require a particular
formatting can be handled by always preserving header case.
