### PR TITLE
[cupertino_http] prepare v3.0.0 release

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.0-wip
+## 3.0.0
 
 * **BREAKING CHANGE:** Remove `shouldUseExtendedBackgroundIdleMode` from
   `URLSessionConfiguration`.

--- a/pkgs/cupertino_http/pubspec.yaml
+++ b/pkgs/cupertino_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cupertino_http
-version: 3.0.0-wip
+version: 3.0.0
 description: >-
   A macOS/iOS Flutter plugin that provides access to the Foundation URL
   Loading System.

--- a/pkgs/flutter_http_example/pubspec.yaml
+++ b/pkgs/flutter_http_example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   cronet_http: ^1.0.0
-  cupertino_http: ^3.0.0
+  cupertino_http: ^2.0.0
   cupertino_icons: ^1.0.2
   fetch_client: ^1.0.2
   flutter:

--- a/pkgs/flutter_http_example/pubspec.yaml
+++ b/pkgs/flutter_http_example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   cronet_http: ^1.0.0
-  cupertino_http: ^2.0.0
+  cupertino_http: ^3.0.0
   cupertino_icons: ^1.0.2
   fetch_client: ^1.0.2
   flutter:


### PR DESCRIPTION
Prepares the release of package:cupertino_http v3.0.0 by removing the -wip suffix from the pubspec and changelog, and updating the examples.