### PR TITLE
fix(cupertino_http): non-apple build

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1
+
+* Fix a [bug](https://github.com/dart-lang/http/issues/1925) where native
+  assets were built on non-Apple platforms.
+* Support the latest semver-major versions of the native assets packages.
+
 ## 3.0.0
 
 * **BREAKING CHANGE:** Remove `shouldUseExtendedBackgroundIdleMode` from

--- a/pkgs/cupertino_http/hook/build.dart
+++ b/pkgs/cupertino_http/hook/build.dart
@@ -2,28 +2,31 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:logging/logging.dart';
 import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> args) async {
-  await build(
-    args,
-    (input, output) async =>
-        CBuilder.library(
-          name: 'cupertino_http',
-          assetName: 'src/native_cupertino_bindings.dart',
-          sources: ['src/native_cupertino_bindings.m'],
-          language: Language.objectiveC,
-          flags: ['-fobjc-arc'],
-        ).run(
-          input: input,
-          output: output,
-          logger: Logger('')
-            ..level = Level.ALL
-            ..onRecord.listen((record) {
-              print('${record.level.name}: ${record.time}: ${record.message}');
-            }),
-        ),
-  );
+  await build(args, (input, output) async {
+    if (input.config.code.targetOS != OS.iOS &&
+        input.config.code.targetOS != OS.macOS) {
+      return;
+    }
+    await CBuilder.library(
+      name: 'cupertino_http',
+      assetName: 'src/native_cupertino_bindings.dart',
+      sources: ['src/native_cupertino_bindings.m'],
+      language: Language.objectiveC,
+      flags: ['-fobjc-arc'],
+    ).run(
+      input: input,
+      output: output,
+      logger: Logger('')
+        ..level = Level.ALL
+        ..onRecord.listen((record) {
+          print('${record.level.name}: ${record.time}: ${record.message}');
+        }),
+    );
+  });
 }

--- a/pkgs/cupertino_http/pubspec.yaml
+++ b/pkgs/cupertino_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cupertino_http
-version: 3.0.0
+version: 3.0.1
 description: >-
   A macOS/iOS Flutter plugin that provides access to the Foundation URL
   Loading System.
@@ -10,12 +10,13 @@ environment:
 
 dependencies:
   async: ^2.5.0
+  code_assets: ^1.0.0
   ffi: ^2.1.0
-  hooks: ^1.0.2
+  hooks: ^2.0.0
   http: ^1.5.0
   http_profile: ^0.1.0
   logging: ^1.3.0
-  native_toolchain_c: ^0.17.6
+  native_toolchain_c: ^0.19.1
   objective_c: ^9.1.0
   web_socket: '>=0.1.5 <2.0.0'
 


### PR DESCRIPTION
* Fixes https://github.com/dart-lang/http/issues/1925 by not building on non-Apple platforms
* Support latest semver-major versions of native asset packages
* Prepare to release 3.0.1

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
