### PR TITLE
fix(cupertino_http): Build hook code assets check

### DIFF
--- a/pkgs/cupertino_http/CHANGELOG.md
+++ b/pkgs/cupertino_http/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+* Fix a [bug](https://github.com/dart-lang/http/issues/1929) where code
+  assets were built on non-code-assets hook invocations.
+
 ## 3.0.1
 
 * Fix a [bug](https://github.com/dart-lang/http/issues/1925) where native

--- a/pkgs/cupertino_http/hook/build.dart
+++ b/pkgs/cupertino_http/hook/build.dart
@@ -9,6 +9,9 @@ import 'package:native_toolchain_c/native_toolchain_c.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
+    if (!input.config.buildCodeAssets) {
+      return;
+    }
     if (input.config.code.targetOS != OS.iOS &&
         input.config.code.targetOS != OS.macOS) {
       return;

--- a/pkgs/cupertino_http/pubspec.yaml
+++ b/pkgs/cupertino_http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cupertino_http
-version: 3.0.1
+version: 3.0.2
 description: >-
   A macOS/iOS Flutter plugin that provides access to the Foundation URL
   Loading System.


### PR DESCRIPTION
Closes: https://github.com/dart-lang/http/issues/1929