### PR TITLE
Fix(http): Release the underlying connection when an AbortableRequest is aborted before its body is read

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,288 +1,288 @@
 ## 1.6.1-wip
 
-- Clarified the behavior of response headers in API documentation comments.
-- Make it more clear that `close` must be called for correctness.
-- Replace references to `dart:web` with `package:web` dartdoc.
-- Preserve header cases in `IOClient`.
-- Fix a [bug](https://github.com/dart-lang/http/issues/1934) to release the
-  underlying connection when an AbortableRequest is aborted before its body is read
+* Clarified the behavior of response headers in API documentation comments.
+* Make it more clear that `close` must be called for correctness.
+* Replace references to `dart:web` with `package:web` dartdoc.
+* Preserve header cases in `IOClient`.
+* Fix a [bug](https://github.com/dart-lang/http/issues/1934) to release the
+  underlying connection when an AbortableRequest is aborted before its body is read.
 
 ## 1.6.0
 
-- **Breaking** Change the behavior of `Request.body` so that a charset
+* **Breaking** Change the behavior of `Request.body` so that a charset
   parameter is only added for text and XML media types. This brings the
   behavior of `package:http` in line with RFC-8259.
-- On the web, fix cancellations for `StreamSubscription`s of response bodies
+* On the web, fix cancellations for `StreamSubscription`s of response bodies
   waiting for the next chunk.
-- Export `MediaType` from `package:http_parser`.
-- Added a section on testing to `README.md`.
+* Export `MediaType` from `package:http_parser`.
+* Added a section on testing to `README.md`.
 
 ## 1.5.0
 
-- Fixed a bug in `IOClient` where the `HttpClient`'s response stream was
+* Fixed a bug in `IOClient` where the `HttpClient`'s response stream was
   cancelled after the response stream was completed.
-- Added support for aborting requests before they complete.
-- Clarify that some header names may not be sent/received.
+* Added support for aborting requests before they complete.
+* Clarify that some header names may not be sent/received.
 
 ## 1.4.0
 
-- Fixed default encoding for application/json without a charset
+* Fixed default encoding for application/json without a charset
   to use utf8 instead of latin1, ensuring proper JSON decoding.
-- Avoid references to `window` in `BrowserClient`, restoring support for web
+* Avoid references to `window` in `BrowserClient`, restoring support for web
   workers and NodeJS.
 
 ## 1.3.0
 
-- Fixed unintended HTML tags in doc comments.
-- Switched `BrowserClient` to use Fetch API instead of `XMLHttpRequest`.
+* Fixed unintended HTML tags in doc comments.
+* Switched `BrowserClient` to use Fetch API instead of `XMLHttpRequest`.
 
 ## 1.2.2
 
-- Require package `web: '>=0.5.0 <2.0.0'`.
+* Require package `web: '>=0.5.0 <2.0.0'`.
 
 ## 1.2.1
 
-- Require Dart `^3.3`
-- Require `package:web` `^0.5.0`.
+* Require Dart `^3.3`
+* Require `package:web` `^0.5.0`.
 
 ## 1.2.0
 
-- Add `MockClient.pngResponse`, which makes it easier to fake image responses.
-- Added the ability to fetch the URL of the response through `BaseResponseWithUrl`.
-- Add the ability to get headers as a `Map<String, List<String>` to
+* Add `MockClient.pngResponse`, which makes it easier to fake image responses.
+* Added the ability to fetch the URL of the response through `BaseResponseWithUrl`.
+* Add the ability to get headers as a `Map<String, List<String>` to
   `BaseResponse`.
 
 ## 1.1.2
 
-- Allow `web: '>=0.3.0 <0.5.0'`.
+* Allow `web: '>=0.3.0 <0.5.0'`.
 
 ## 1.1.1
 
-- `BrowserClient` throws `ClientException` when the `'Content-Length'` header
+* `BrowserClient` throws `ClientException` when the `'Content-Length'` header
   is invalid.
-- `IOClient` trims trailing whitespace on header values.
-- Require Dart 3.2
-- Browser: support Wasm by using `package:web`.
+* `IOClient` trims trailing whitespace on header values.
+* Require Dart 3.2
+* Browser: support Wasm by using `package:web`.
 
 ## 1.1.0
 
-- Add better error messages for `SocketException`s when using `IOClient`.
-- Make `StreamedRequest.sink` a `StreamSink`. This makes `request.sink.close()`
+* Add better error messages for `SocketException`s when using `IOClient`.
+* Make `StreamedRequest.sink` a `StreamSink`. This makes `request.sink.close()`
   return a `Future` instead of `void`, but the returned future should _not_ be
   awaited. The Future returned from `sink.close()` may only complete after the
   request has been sent.
 
 ## 1.0.0
 
-- Requires Dart 3.0 or later.
-- Add `base`, `final`, and `interface` modifiers to some classes.
+* Requires Dart 3.0 or later.
+* Add `base`, `final`, and `interface` modifiers to some classes.
 
 ## 0.13.6
 
-- `BrowserClient` throws an exception if `send` is called after `close`.
-- If `no_default_http_client=true` is set in the environment then disk usage
+* `BrowserClient` throws an exception if `send` is called after `close`.
+* If `no_default_http_client=true` is set in the environment then disk usage
   is reduced in some circumstances.
-- Require Dart 2.19
+* Require Dart 2.19
 
 ## 0.13.5
 
-- Allow async callbacks in RetryClient.
-- In `MockHttpClient` use the callback returned `Response.request` instead of
+* Allow async callbacks in RetryClient.
+* In `MockHttpClient` use the callback returned `Response.request` instead of
   the argument value to give more control to the callback. This may be breaking
   for callbacks which return incomplete Responses and relied on the default.
 
 ## 0.13.4
 
-- Throw a more useful error when a client is used after it has been closed.
-- Require Dart 2.14.
+* Throw a more useful error when a client is used after it has been closed.
+* Require Dart 2.14.
 
 ## 0.13.3
 
-- Validate that the `method` parameter of BaseRequest is a valid "token".
+* Validate that the `method` parameter of BaseRequest is a valid "token".
 
 ## 0.13.2
 
-- Add `package:http/retry.dart` with `RetryClient`. This is the same
+* Add `package:http/retry.dart` with `RetryClient`. This is the same
   implementation as `package:http_retry` which will be discontinued.
 
 ## 0.13.1
 
-- Fix code samples in `README` to pass a `Uri` instance.
+* Fix code samples in `README` to pass a `Uri` instance.
 
 ## 0.13.0
 
-- Migrate to null safety.
-- Add `const` constructor to `ByteStream`.
-- Migrate `BrowserClient` from `blob` to `arraybuffer`.
-- **Breaking** All APIs which previously allowed a `String` or `Uri` to be
+* Migrate to null safety.
+* Add `const` constructor to `ByteStream`.
+* Migrate `BrowserClient` from `blob` to `arraybuffer`.
+* **Breaking** All APIs which previously allowed a `String` or `Uri` to be
   passed now require a `Uri`.
-- **Breaking** Added a `body` and `encoding` argument to `Client.delete`. This
+* **Breaking** Added a `body` and `encoding` argument to `Client.delete`. This
   is only breaking for implementations which override that method.
 
 ## 0.12.2
 
-- Fix error handler callback type for response stream errors to avoid masking
+* Fix error handler callback type for response stream errors to avoid masking
   root causes.
 
 ## 0.12.1
 
-- Add `IOStreamedResponse` which includes the ability to detach the socket.
+* Add `IOStreamedResponse` which includes the ability to detach the socket.
   When sending a request with an `IOClient` the response will be an
   `IOStreamedResponse`.
-- Remove dependency on `package:async`.
+* Remove dependency on `package:async`.
 
 ## 0.12.0+4
 
-- Fix a bug setting the `'content-type'` header in `MultipartRequest`.
+* Fix a bug setting the `'content-type'` header in `MultipartRequest`.
 
 ## 0.12.0+3
 
-- Documentation fixes.
+* Documentation fixes.
 
 ## 0.12.0+2
 
-- Documentation fixes.
+* Documentation fixes.
 
 ## 0.12.0
 
 ### New Features
 
-- The regular `Client` factory constructor is now usable anywhere that `dart:io`
+* The regular `Client` factory constructor is now usable anywhere that `dart:io`
   or `dart:html` are available, and will give you an `IoClient` or
   `BrowserClient` respectively.
-- The `package:http/http.dart` import is now safe to use on the web (or
+* The `package:http/http.dart` import is now safe to use on the web (or
   anywhere that either `dart:io` or `dart:html` are available).
 
 ### Breaking Changes
 
-- In order to use or reference the `IoClient` directly, you will need to import
+* In order to use or reference the `IoClient` directly, you will need to import
   the new `package:http/io_client.dart` import. This is typically only necessary
   if you are passing a custom `HttpClient` instance to the constructor, in which
   case you are already giving up support for web.
 
 ## 0.11.3+17
 
-- Use new Dart 2 constant names. This branch is only for allowing existing
+* Use new Dart 2 constant names. This branch is only for allowing existing
   code to keep running under Dart 2.
 
 ## 0.11.3+16
 
-- Stop depending on the `stack_trace` package.
+* Stop depending on the `stack_trace` package.
 
 ## 0.11.3+15
 
-- Declare support for `async` 2.0.0.
+* Declare support for `async` 2.0.0.
 
 ## 0.11.3+14
 
-- Remove single quote ("'" - ASCII 39) from boundary characters.
+* Remove single quote ("'" - ASCII 39) from boundary characters.
   Causes issues with Google Cloud Storage.
 
 ## 0.11.3+13
 
-- remove boundary characters that package:http_parser cannot parse.
+* remove boundary characters that package:http_parser cannot parse.
 
 ## 0.11.3+12
 
-- Don't quote the boundary header for `MultipartRequest`. This is more
+* Don't quote the boundary header for `MultipartRequest`. This is more
   compatible with server quirks.
 
 ## 0.11.3+11
 
-- Fix the SDK constraint to only include SDK versions that support importing
+* Fix the SDK constraint to only include SDK versions that support importing
   `dart:io` everywhere.
 
 ## 0.11.3+10
 
-- Stop using `dart:mirrors`.
+* Stop using `dart:mirrors`.
 
 ## 0.11.3+9
 
-- Remove an extra newline in multipart chunks.
+* Remove an extra newline in multipart chunks.
 
 ## 0.11.3+8
 
-- Properly specify `Content-Transfer-Encoding` for multipart chunks.
+* Properly specify `Content-Transfer-Encoding` for multipart chunks.
 
 ## 0.11.3+7
 
-- Declare compatibility with `http_parser` 3.0.0.
+* Declare compatibility with `http_parser` 3.0.0.
 
 ## 0.11.3+6
 
-- Fix one more strong mode warning in `http/testing.dart`.
+* Fix one more strong mode warning in `http/testing.dart`.
 
 ## 0.11.3+5
 
-- Fix some lingering strong mode warnings.
+* Fix some lingering strong mode warnings.
 
 ## 0.11.3+4
 
-- Fix all strong mode warnings.
+* Fix all strong mode warnings.
 
 ## 0.11.3+3
 
-- Support `http_parser` 2.0.0.
+* Support `http_parser` 2.0.0.
 
 ## 0.11.3+2
 
-- Require Dart SDK >= 1.9.0
+* Require Dart SDK >= 1.9.0
 
-- Eliminate many uses of `Chain.track` from the `stack_trace` package.
+* Eliminate many uses of `Chain.track` from the `stack_trace` package.
 
 ## 0.11.3+1
 
-- Support `http_parser` 1.0.0.
+* Support `http_parser` 1.0.0.
 
 ## 0.11.3
 
-- Add a `Client.patch` shortcut method and a matching top-level `patch` method.
+* Add a `Client.patch` shortcut method and a matching top-level `patch` method.
 
 ## 0.11.2
 
-- Add a `BrowserClient.withCredentials` property.
+* Add a `BrowserClient.withCredentials` property.
 
 ## 0.11.1+3
 
-- Properly namespace an internal library name.
+* Properly namespace an internal library name.
 
 ## 0.11.1+2
 
-- Widen the version constraint on `unittest`.
+* Widen the version constraint on `unittest`.
 
 ## 0.11.1+1
 
-- Widen the version constraint for `stack_trace`.
+* Widen the version constraint for `stack_trace`.
 
 ## 0.11.1
 
-- Expose the `IOClient` class which wraps a `dart:io` `HttpClient`.
+* Expose the `IOClient` class which wraps a `dart:io` `HttpClient`.
 
 ## 0.11.0+1
 
-- Fix a bug in handling errors in decoding XMLHttpRequest responses for
+* Fix a bug in handling errors in decoding XMLHttpRequest responses for
   `BrowserClient`.
 
 ## 0.11.0
 
-- The package no longer depends on `dart:io`. The `BrowserClient` class in
+* The package no longer depends on `dart:io`. The `BrowserClient` class in
   `package:http/browser_client.dart` can now be used to make requests on the
   browser.
 
-- Change `MultipartFile.contentType` from `dart:io`'s `ContentType` type to
+* Change `MultipartFile.contentType` from `dart:io`'s `ContentType` type to
   `http_parser`'s `MediaType` type.
 
-- Exceptions are now of type `ClientException` rather than `dart:io`'s
+* Exceptions are now of type `ClientException` rather than `dart:io`'s
   `HttpException`.
 
 ## 0.10.0
 
-- Make `BaseRequest.contentLength` and `BaseResponse.contentLength` use `null`
+* Make `BaseRequest.contentLength` and `BaseResponse.contentLength` use `null`
   to indicate an unknown content length rather than -1.
 
-- The `contentLength` parameter to `new BaseResponse` is now named rather than
+* The `contentLength` parameter to `new BaseResponse` is now named rather than
   positional.
 
-- Make request headers case-insensitive.
+* Make request headers case-insensitive.
 
-- Make `MultipartRequest` more closely adhere to browsers' encoding conventions.
+* Make `MultipartRequest` more closely adhere to browsers' encoding conventions.

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Replace references to `dart:web` with `package:web` dartdoc.
 * Preserve header cases in `IOClient`.
 * Fix a [bug](https://github.com/dart-lang/http/issues/1934) to release the
-  underlying connection when an AbortableRequest is aborted before its body is read.
+  underlying connection when an `AbortableRequest` is aborted before its body is read.
 
 ## 1.6.0
 

--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,286 +1,288 @@
 ## 1.6.1-wip
 
-* Clarified the behavior of response headers in API documentation comments.
-* Make it more clear that `close` must be called for correctness.
-* Replace references to `dart:web` with `package:web` dartdoc.
-* Preserve header cases in `IOClient`.
+- Clarified the behavior of response headers in API documentation comments.
+- Make it more clear that `close` must be called for correctness.
+- Replace references to `dart:web` with `package:web` dartdoc.
+- Preserve header cases in `IOClient`.
+- Fix a [bug](https://github.com/dart-lang/http/issues/1934) to release the
+  underlying connection when an AbortableRequest is aborted before its body is read
 
 ## 1.6.0
 
-* **Breaking** Change the behavior of `Request.body` so that a charset
+- **Breaking** Change the behavior of `Request.body` so that a charset
   parameter is only added for text and XML media types. This brings the
   behavior of `package:http` in line with RFC-8259.
-* On the web, fix cancellations for `StreamSubscription`s of response bodies
+- On the web, fix cancellations for `StreamSubscription`s of response bodies
   waiting for the next chunk.
-* Export `MediaType` from `package:http_parser`.
-* Added a section on testing to `README.md`.
+- Export `MediaType` from `package:http_parser`.
+- Added a section on testing to `README.md`.
 
 ## 1.5.0
 
-* Fixed a bug in `IOClient` where the `HttpClient`'s response stream was
+- Fixed a bug in `IOClient` where the `HttpClient`'s response stream was
   cancelled after the response stream was completed.
-* Added support for aborting requests before they complete.
-* Clarify that some header names may not be sent/received.
+- Added support for aborting requests before they complete.
+- Clarify that some header names may not be sent/received.
 
 ## 1.4.0
 
-* Fixed default encoding for application/json without a charset
+- Fixed default encoding for application/json without a charset
   to use utf8 instead of latin1, ensuring proper JSON decoding.
-* Avoid references to `window` in `BrowserClient`, restoring support for web
+- Avoid references to `window` in `BrowserClient`, restoring support for web
   workers and NodeJS.
 
 ## 1.3.0
 
-* Fixed unintended HTML tags in doc comments.
-* Switched `BrowserClient` to use Fetch API instead of `XMLHttpRequest`.
+- Fixed unintended HTML tags in doc comments.
+- Switched `BrowserClient` to use Fetch API instead of `XMLHttpRequest`.
 
 ## 1.2.2
 
-* Require package `web: '>=0.5.0 <2.0.0'`.
+- Require package `web: '>=0.5.0 <2.0.0'`.
 
 ## 1.2.1
 
-* Require Dart `^3.3`
-* Require `package:web` `^0.5.0`.
+- Require Dart `^3.3`
+- Require `package:web` `^0.5.0`.
 
 ## 1.2.0
 
-* Add `MockClient.pngResponse`, which makes it easier to fake image responses.
-* Added the ability to fetch the URL of the response through `BaseResponseWithUrl`.
-* Add the ability to get headers as a `Map<String, List<String>` to
+- Add `MockClient.pngResponse`, which makes it easier to fake image responses.
+- Added the ability to fetch the URL of the response through `BaseResponseWithUrl`.
+- Add the ability to get headers as a `Map<String, List<String>` to
   `BaseResponse`.
 
 ## 1.1.2
 
-* Allow `web: '>=0.3.0 <0.5.0'`.
+- Allow `web: '>=0.3.0 <0.5.0'`.
 
 ## 1.1.1
 
-* `BrowserClient` throws `ClientException` when the `'Content-Length'` header
+- `BrowserClient` throws `ClientException` when the `'Content-Length'` header
   is invalid.
-* `IOClient` trims trailing whitespace on header values.
-* Require Dart 3.2
-* Browser: support Wasm by using `package:web`.
+- `IOClient` trims trailing whitespace on header values.
+- Require Dart 3.2
+- Browser: support Wasm by using `package:web`.
 
 ## 1.1.0
 
-* Add better error messages for `SocketException`s when using `IOClient`.
-* Make `StreamedRequest.sink` a `StreamSink`. This makes `request.sink.close()`
+- Add better error messages for `SocketException`s when using `IOClient`.
+- Make `StreamedRequest.sink` a `StreamSink`. This makes `request.sink.close()`
   return a `Future` instead of `void`, but the returned future should _not_ be
   awaited. The Future returned from `sink.close()` may only complete after the
   request has been sent.
 
 ## 1.0.0
 
-* Requires Dart 3.0 or later.
-* Add `base`, `final`, and `interface` modifiers to some classes.
+- Requires Dart 3.0 or later.
+- Add `base`, `final`, and `interface` modifiers to some classes.
 
 ## 0.13.6
 
-* `BrowserClient` throws an exception if `send` is called after `close`.
-* If `no_default_http_client=true` is set in the environment then disk usage
+- `BrowserClient` throws an exception if `send` is called after `close`.
+- If `no_default_http_client=true` is set in the environment then disk usage
   is reduced in some circumstances.
-* Require Dart 2.19
+- Require Dart 2.19
 
 ## 0.13.5
 
-* Allow async callbacks in RetryClient.
-* In `MockHttpClient` use the callback returned `Response.request` instead of
+- Allow async callbacks in RetryClient.
+- In `MockHttpClient` use the callback returned `Response.request` instead of
   the argument value to give more control to the callback. This may be breaking
   for callbacks which return incomplete Responses and relied on the default.
 
 ## 0.13.4
 
-* Throw a more useful error when a client is used after it has been closed.
-* Require Dart 2.14.
+- Throw a more useful error when a client is used after it has been closed.
+- Require Dart 2.14.
 
 ## 0.13.3
 
-* Validate that the `method` parameter of BaseRequest is a valid "token".
+- Validate that the `method` parameter of BaseRequest is a valid "token".
 
 ## 0.13.2
 
-* Add `package:http/retry.dart` with `RetryClient`. This is the same
+- Add `package:http/retry.dart` with `RetryClient`. This is the same
   implementation as `package:http_retry` which will be discontinued.
 
 ## 0.13.1
 
-* Fix code samples in `README` to pass a `Uri` instance.
+- Fix code samples in `README` to pass a `Uri` instance.
 
 ## 0.13.0
 
-* Migrate to null safety.
-* Add `const` constructor to `ByteStream`.
-* Migrate `BrowserClient` from `blob` to `arraybuffer`.
-* **Breaking** All APIs which previously allowed a `String` or `Uri` to be
+- Migrate to null safety.
+- Add `const` constructor to `ByteStream`.
+- Migrate `BrowserClient` from `blob` to `arraybuffer`.
+- **Breaking** All APIs which previously allowed a `String` or `Uri` to be
   passed now require a `Uri`.
-* **Breaking** Added a `body` and `encoding` argument to `Client.delete`. This
+- **Breaking** Added a `body` and `encoding` argument to `Client.delete`. This
   is only breaking for implementations which override that method.
 
 ## 0.12.2
 
-* Fix error handler callback type for response stream errors to avoid masking
+- Fix error handler callback type for response stream errors to avoid masking
   root causes.
 
 ## 0.12.1
 
-* Add `IOStreamedResponse` which includes the ability to detach the socket.
+- Add `IOStreamedResponse` which includes the ability to detach the socket.
   When sending a request with an `IOClient` the response will be an
   `IOStreamedResponse`.
-* Remove dependency on `package:async`.
+- Remove dependency on `package:async`.
 
 ## 0.12.0+4
 
-* Fix a bug setting the `'content-type'` header in `MultipartRequest`.
+- Fix a bug setting the `'content-type'` header in `MultipartRequest`.
 
 ## 0.12.0+3
 
-* Documentation fixes.
+- Documentation fixes.
 
 ## 0.12.0+2
 
-* Documentation fixes.
+- Documentation fixes.
 
 ## 0.12.0
 
 ### New Features
 
-* The regular `Client` factory constructor is now usable anywhere that `dart:io`
+- The regular `Client` factory constructor is now usable anywhere that `dart:io`
   or `dart:html` are available, and will give you an `IoClient` or
   `BrowserClient` respectively.
-* The `package:http/http.dart` import is now safe to use on the web (or
+- The `package:http/http.dart` import is now safe to use on the web (or
   anywhere that either `dart:io` or `dart:html` are available).
 
 ### Breaking Changes
 
-* In order to use or reference the `IoClient` directly, you will need to import
+- In order to use or reference the `IoClient` directly, you will need to import
   the new `package:http/io_client.dart` import. This is typically only necessary
   if you are passing a custom `HttpClient` instance to the constructor, in which
   case you are already giving up support for web.
 
 ## 0.11.3+17
 
-* Use new Dart 2 constant names. This branch is only for allowing existing
+- Use new Dart 2 constant names. This branch is only for allowing existing
   code to keep running under Dart 2.
 
 ## 0.11.3+16
 
-* Stop depending on the `stack_trace` package.
+- Stop depending on the `stack_trace` package.
 
 ## 0.11.3+15
 
-* Declare support for `async` 2.0.0.
+- Declare support for `async` 2.0.0.
 
 ## 0.11.3+14
 
-* Remove single quote ("'" - ASCII 39) from boundary characters.
+- Remove single quote ("'" - ASCII 39) from boundary characters.
   Causes issues with Google Cloud Storage.
 
 ## 0.11.3+13
 
-* remove boundary characters that package:http_parser cannot parse.
+- remove boundary characters that package:http_parser cannot parse.
 
 ## 0.11.3+12
 
-* Don't quote the boundary header for `MultipartRequest`. This is more
+- Don't quote the boundary header for `MultipartRequest`. This is more
   compatible with server quirks.
 
 ## 0.11.3+11
 
-* Fix the SDK constraint to only include SDK versions that support importing
+- Fix the SDK constraint to only include SDK versions that support importing
   `dart:io` everywhere.
 
 ## 0.11.3+10
 
-* Stop using `dart:mirrors`.
+- Stop using `dart:mirrors`.
 
 ## 0.11.3+9
 
-* Remove an extra newline in multipart chunks.
+- Remove an extra newline in multipart chunks.
 
 ## 0.11.3+8
 
-* Properly specify `Content-Transfer-Encoding` for multipart chunks.
+- Properly specify `Content-Transfer-Encoding` for multipart chunks.
 
 ## 0.11.3+7
 
-* Declare compatibility with `http_parser` 3.0.0.
+- Declare compatibility with `http_parser` 3.0.0.
 
 ## 0.11.3+6
 
-* Fix one more strong mode warning in `http/testing.dart`.
+- Fix one more strong mode warning in `http/testing.dart`.
 
 ## 0.11.3+5
 
-* Fix some lingering strong mode warnings.
+- Fix some lingering strong mode warnings.
 
 ## 0.11.3+4
 
-* Fix all strong mode warnings.
+- Fix all strong mode warnings.
 
 ## 0.11.3+3
 
-* Support `http_parser` 2.0.0.
+- Support `http_parser` 2.0.0.
 
 ## 0.11.3+2
 
-* Require Dart SDK >= 1.9.0
+- Require Dart SDK >= 1.9.0
 
-* Eliminate many uses of `Chain.track` from the `stack_trace` package.
+- Eliminate many uses of `Chain.track` from the `stack_trace` package.
 
 ## 0.11.3+1
 
-* Support `http_parser` 1.0.0.
+- Support `http_parser` 1.0.0.
 
 ## 0.11.3
 
-* Add a `Client.patch` shortcut method and a matching top-level `patch` method.
+- Add a `Client.patch` shortcut method and a matching top-level `patch` method.
 
 ## 0.11.2
 
-* Add a `BrowserClient.withCredentials` property.
+- Add a `BrowserClient.withCredentials` property.
 
 ## 0.11.1+3
 
-* Properly namespace an internal library name.
+- Properly namespace an internal library name.
 
 ## 0.11.1+2
 
-* Widen the version constraint on `unittest`.
+- Widen the version constraint on `unittest`.
 
 ## 0.11.1+1
 
-* Widen the version constraint for `stack_trace`.
+- Widen the version constraint for `stack_trace`.
 
 ## 0.11.1
 
-* Expose the `IOClient` class which wraps a `dart:io` `HttpClient`.
+- Expose the `IOClient` class which wraps a `dart:io` `HttpClient`.
 
 ## 0.11.0+1
 
-* Fix a bug in handling errors in decoding XMLHttpRequest responses for
+- Fix a bug in handling errors in decoding XMLHttpRequest responses for
   `BrowserClient`.
 
 ## 0.11.0
 
-* The package no longer depends on `dart:io`. The `BrowserClient` class in
+- The package no longer depends on `dart:io`. The `BrowserClient` class in
   `package:http/browser_client.dart` can now be used to make requests on the
   browser.
 
-* Change `MultipartFile.contentType` from `dart:io`'s `ContentType` type to
+- Change `MultipartFile.contentType` from `dart:io`'s `ContentType` type to
   `http_parser`'s `MediaType` type.
 
-* Exceptions are now of type `ClientException` rather than `dart:io`'s
+- Exceptions are now of type `ClientException` rather than `dart:io`'s
   `HttpException`.
 
 ## 0.10.0
 
-* Make `BaseRequest.contentLength` and `BaseResponse.contentLength` use `null`
+- Make `BaseRequest.contentLength` and `BaseResponse.contentLength` use `null`
   to indicate an unknown content length rather than -1.
 
-* The `contentLength` parameter to `new BaseResponse` is now named rather than
+- The `contentLength` parameter to `new BaseResponse` is now named rather than
   positional.
 
-* Make request headers case-insensitive.
+- Make request headers case-insensitive.
 
-* Make `MultipartRequest` more closely adhere to browsers' encoding conventions.
+- Make `MultipartRequest` more closely adhere to browsers' encoding conventions.

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -120,20 +120,25 @@ class IOClient extends BaseClient {
         ioRequest.headers.set(name, value, preserveHeaderCase: true);
       });
 
-      // SDK request aborting is only effective up until the request is closed,
-      // at which point the full response always becomes available.
-      // This occurs at `pipe`, which automatically closes the request once the
-      // request stream has been pumped in.
+      // SDK request aborting is only effective up until the request is
+      // closed, at which point the full response always becomes available.
+      // This happens at `pipe`, which closes the request once the request
+      // stream is pumped in.
       //
-      // Therefore, we have multiple strategies:
-      //  * If the user aborts before we have a response, we can use SDK abort,
-      //    which causes the `pipe` (and therefore this method) to throw the
-      //    aborted error
-      //  * If the user aborts after we have a response but before they listen
-      //    to it, we immediately emit the aborted error then close the response
-      //    as soon as they listen to it
-      //  * If the user aborts whilst streaming the response, we inject the
-      //    aborted error, then close the response
+      // Abort is therefore handled in two phases, split on the `pipe` boundary:
+      //
+      //  * Before we have a response: use SDK abort, which makes `pipe` (and so
+      //    this method) throw the aborted error.
+      //
+      //  * After we have a response, WE own the `HttpClientResponse` and must
+      //    release it ourselves; otherwise the connection stays open
+      //    waiting for a body that will never be read.
+      //    One handler covers all three cases:
+      //      - Never listened to: cancel the native response to destroy the
+      //        connection.
+      //      - Streaming: inject the aborted error into the wrapper and cancel
+      //        the active subscription, which destroys the connection.
+      //      - Already fully read: nothing to release, so it's a no-op.
 
       var isAborted = false;
       var hasResponse = false;
@@ -153,32 +158,32 @@ class IOClient extends BaseClient {
       hasResponse = true;
 
       StreamSubscription<List<int>>? ioResponseSubscription;
-
       late final StreamController<List<int>> responseController;
+      var responseListenStarted = false;
+
+      void abortResponse() {
+        if (!responseController.isClosed) {
+          responseController
+            ..addError(RequestAbortedException(request.url))
+            ..close();
+        }
+        if (responseListenStarted) {
+          unawaited(ioResponseSubscription?.cancel());
+        } else {
+          unawaited(response.listen(null, onError: (_, __) {}).cancel());
+        }
+      }
+
       responseController = StreamController(
         onListen: () {
-          if (isAborted) {
-            responseController
-              ..addError(RequestAbortedException(request.url))
-              ..close();
-            return;
-          } else if (request case Abortable(:final abortTrigger?)) {
-            abortTrigger.whenComplete(() {
-              if (!responseController.isClosed) {
-                responseController
-                  ..addError(RequestAbortedException(request.url))
-                  ..close();
-              }
-              ioResponseSubscription?.cancel();
-            });
-          }
-
+          if (isAborted) return;
+          responseListenStarted = true;
           ioResponseSubscription = response.listen(
             responseController.add,
             onDone: () {
-              // `reponseController.close` will trigger the `onCancel` callback.
-              // Assign `ioResponseSubscription` to `null` to avoid calling its
-              // `cancel` method.
+              // `responseController.close` will trigger the `onCancel`
+              // callback. Assign `ioResponseSubscription` to `null` to avoid
+              // calling its `cancel` method.
               ioResponseSubscription = null;
               unawaited(responseController.close());
             },
@@ -199,6 +204,10 @@ class IOClient extends BaseClient {
         onCancel: () => ioResponseSubscription?.cancel(),
         sync: true,
       );
+
+      if (request case Abortable(:final abortTrigger?)) {
+        unawaited(abortTrigger.whenComplete(abortResponse));
+      }
 
       var headers = <String, String>{};
       response.headers.forEach((key, values) {

--- a/pkgs/http/test/io/client_test.dart
+++ b/pkgs/http/test/io/client_test.dart
@@ -36,6 +36,79 @@ void main() {
     serverUrl = await startServer();
   });
 
+  test('aborting without reading the response frees the underlying connection',
+      () async {
+    // Pool of exactly one: a held connection makes the next request hang.
+    final ioClient = HttpClient()..maxConnectionsPerHost = 1;
+    final client = http_io.IOClient(ioClient);
+    addTearDown(client.close);
+
+    final abortTrigger = Completer<void>();
+    final request = http.AbortableRequest('GET', serverUrl,
+        abortTrigger: abortTrigger.future);
+
+    await client.send(request);
+
+    // Abort after we have the response but before reading it.
+    abortTrigger.complete();
+
+    // Can only succeed if the aborted request's connection was released.
+    final request2 = http.Request('GET', serverUrl);
+    final response2 =
+        await client.send(request2).timeout(const Duration(seconds: 5));
+    final body2 = await http.Response.fromStream(response2);
+
+    expect(response2.statusCode, 200);
+    expect(body2.body, isNotEmpty);
+  });
+
+  test('aborting after the response is fully read raises no async error',
+      () async {
+    final errors = <Object>[];
+
+    await runZonedGuarded(() async {
+      final client = http_io.IOClient();
+      addTearDown(client.close);
+
+      final abortTrigger = Completer<void>();
+      final request = http.AbortableRequest('GET', serverUrl,
+          abortTrigger: abortTrigger.future);
+
+      final response = await client.send(request);
+      final body = await http.Response.fromStream(response);
+      expect(body.statusCode, 200);
+
+      abortTrigger.complete();
+      await Future<void>.delayed(Duration.zero); // let the handlers run
+    }, (e, _) => errors.add(e));
+
+    expect(errors, isEmpty);
+  });
+
+  test('aborting while streaming frees the connection', () async {
+    final ioClient = HttpClient()..maxConnectionsPerHost = 1; // pool of 1
+    final client = http_io.IOClient(ioClient);
+    addTearDown(client.close);
+
+    final abortTrigger = Completer<void>();
+    final request = http.AbortableRequest('GET', serverUrl,
+        abortTrigger: abortTrigger.future);
+
+    final response = await client.send(request);
+
+    // Start streaming, then abort before the body's I/O events are delivered.
+    response.stream.listen((_) {}, onError: (_) {});
+    abortTrigger.complete();
+
+    // Only returns if the aborted connection was released back to the pool.
+    final response2 = await client
+        .send(http.Request('GET', serverUrl))
+        .timeout(const Duration(seconds: 5));
+    final body2 = await http.Response.fromStream(response2);
+    expect(response2.statusCode, 200);
+    expect(body2.body, isNotEmpty);
+  });
+
   test('#send a StreamedRequest', () async {
     var client = http.Client();
     var request = http.StreamedRequest('POST', serverUrl)


### PR DESCRIPTION
After `send` returns, `IOClient` owns the `dart:io` `HttpClientResponse` but subscribed to it lazily — only when the wrapper stream was listened to. Aborting in the window between "response received" and "body listened" closed the wrapper without ever touching the native response, so `dart:io` kept the connection open waiting for a body no one would read. With a bounded pool, the next request hung until timeout.

Abort after `pipe` is now handled by a single `abortResponse` that covers all three states:

- **Never listened to** — cancel the native response to release the connection.
- **Streaming** — emit `RequestAbortedException` and cancel the live subscription.
- **Already fully read** — no-op.

The wrapper still emits `RequestAbortedException` and closes. The body is destroyed, not drained.

**Tests**
- `aborting without reading the response frees the underlying connection`
- `aborting after the response is fully read raises no async error`
- `aborting while streaming frees the connection`

Fixes #1934 

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
