### PR TITLE
[http] Fix incorrect IOClient documentation for non-2xx HTTP responses

### DIFF
--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -68,16 +68,16 @@ class _IOStreamedResponseV2 extends IOStreamedResponse
 /// callers to get more detailed exception information for socket-level
 /// failures, if desired.
 ///
-/// For example:
+/// Example:
 /// ```dart
-/// final client = http.Client();
+/// final BaseClient client = IOClient();
 /// late String data;
 /// try {
 ///   data = await client.read(Uri.https('example.com', ''));
-/// } on SocketException catch (e) {
-///   // Exception is transport-related, check `e.osError` for more details.
 /// } on http.ClientException catch (e) {
-///   // Exception is HTTP-related (e.g. the server returned a 404 status code).
+///   // Exception is transport-related.
+///   // If platform-specific socket details are needed, catch `SocketException`
+///   // before `ClientException` (or without `ClientException`) and inspect `osError` for more details.
 ///   // If the handler for `SocketException` were removed then all exceptions
 ///   // would be caught by this handler.
 /// }

--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -70,7 +70,7 @@ class _IOStreamedResponseV2 extends IOStreamedResponse
 ///
 /// Example:
 /// ```dart
-/// final BaseClient client = IOClient();
+/// final client = IOClient();
 /// late String data;
 /// try {
 ///   data = await client.read(Uri.https('example.com', ''));


### PR DESCRIPTION
Fixes #1947

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
