### PR TITLE
docs(readme): add close method override in UserAgentClient example

### DIFF
--- a/pkgs/http/README.md
+++ b/pkgs/http/README.md
@@ -80,6 +80,9 @@ class UserAgentClient extends http.BaseClient {
     request.headers['user-agent'] = userAgent;
     return _inner.send(request);
   }
+
+  @override
+  void close() => _inner.close();
 }
 ```
 ## Testing


### PR DESCRIPTION
It seems that `close()` is a no-op without an override in this case:

```dart
import 'package:http/http.dart' as http;
import 'package:http/io.dart';

// Copied from https://pub.dev/packages/http#using
class UserAgentClient(final String userAgent, final http.Client _inner) extends http.BaseClient {

  @override
  Future<http.StreamedResponse> send(http.BaseRequest request) {
    request.headers['user-agent'] = userAgent;
    return _inner.send(request);
  }
}

void main() {
  final http.BaseClient client = UserAgentClient('user-agent', IOClient());
  client.close(); // No-op. Does not call IOClient.close()
}
```

I'm not sure if I misunderstood something or am consuming the API in the wrong way.

If the intended way to close the HTTP client is:

```dart
void main() {
  final http.BaseClient innerClient = IOClient();
  
  final http.BaseClient client = UserAgentClient('user-agent', innerClient);
   // Send requests using "client"...

  innerClient.close();
}
```

Then the current example code is as intended. But even then, I would throw a Dart error when calling `UserAgentClient.close()`, to avoid silent programming bugs.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
