### PR TITLE
Fix RFC 850 two-digit year parsing

### DIFF
--- a/pkgs/http_parser/CHANGELOG.md
+++ b/pkgs/http_parser/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 4.1.3-wip
 
+* Apply the RFC 9110 50-year rule when parsing RFC 850 dates.
 * Replace reference to `dart:web` with `package:web` in README.md.
 
 ## 4.1.2

--- a/pkgs/http_parser/CHANGELOG.md
+++ b/pkgs/http_parser/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 4.1.3-wip
 
-* Apply the RFC 9110 50-year rule when parsing RFC 850 dates.
+* **BREAKING:** Apply the RFC 9110 50-year rule when parsing RFC 850 dates.
+  Previously, two-digit years were always interpreted as years between 1900
+  and 1999.
 * Replace reference to `dart:web` with `package:web` in README.md.
 
 ## 4.1.2

--- a/pkgs/http_parser/lib/src/http_date.dart
+++ b/pkgs/http_parser/lib/src/http_date.dart
@@ -68,6 +68,11 @@ DateTime parseHttpDate(String date) =>
         scanner.expect('-');
         final month = _parseMonth(scanner);
         scanner.expect('-');
+        // RFC 9110, Section 5.6.7 says:
+        // Recipients of a timestamp value in rfc850-date format, which uses a
+        // two-digit year, MUST interpret a timestamp that appears to be more
+        // than 50 years in the future as representing the most recent year in the
+        // past that had the same last two digits.
         final currentYear = DateTime.now().toUtc().year;
         var year = currentYear - currentYear % 100 + _parseInt(scanner, 2);
         if (year > currentYear + 50) year -= 100;

--- a/pkgs/http_parser/lib/src/http_date.dart
+++ b/pkgs/http_parser/lib/src/http_date.dart
@@ -71,8 +71,8 @@ DateTime parseHttpDate(String date) =>
         // RFC 9110, Section 5.6.7 says:
         // Recipients of a timestamp value in rfc850-date format, which uses a
         // two-digit year, MUST interpret a timestamp that appears to be more
-        // than 50 years in the future as representing the most recent year in the
-        // past that had the same last two digits.
+        // than 50 years in the future as representing the most recent year
+        // in the past that had the same last two digits.
         final currentYear = DateTime.now().toUtc().year;
         var year = currentYear - currentYear % 100 + _parseInt(scanner, 2);
         if (year > currentYear + 50) year -= 100;

--- a/pkgs/http_parser/lib/src/http_date.dart
+++ b/pkgs/http_parser/lib/src/http_date.dart
@@ -55,7 +55,7 @@ String formatHttpDate(DateTime date) {
 
 /// Parses an HTTP-formatted date into a UTC [DateTime].
 ///
-/// This follows [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3).
+/// This follows [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.6.7).
 /// It will throw a [FormatException] if [date] is invalid.
 DateTime parseHttpDate(String date) =>
     wrapFormatException('HTTP date', date, () {
@@ -68,7 +68,9 @@ DateTime parseHttpDate(String date) =>
         scanner.expect('-');
         final month = _parseMonth(scanner);
         scanner.expect('-');
-        final year = 1900 + _parseInt(scanner, 2);
+        final currentYear = DateTime.now().toUtc().year;
+        var year = currentYear - currentYear % 100 + _parseInt(scanner, 2);
+        if (year > currentYear + 50) year -= 100;
         scanner.expect(' ');
         final time = _parseTime(scanner);
         scanner.expect(' GMT');

--- a/pkgs/http_parser/test/http_date_test.dart
+++ b/pkgs/http_parser/test/http_date_test.dart
@@ -155,6 +155,13 @@ void main() {
         expect(date.timeZoneName, equals('UTC'));
       });
 
+      test('applies the two-digit year rule', () {
+        expect(
+          parseHttpDate('Sunday, 21-Jun-26 07:28:00 GMT'),
+          DateTime.utc(2026, DateTime.june, 21, 7, 28),
+        );
+      });
+
       test('whitespace is required', () {
         expect(() => parseHttpDate('Sunday,06-Nov-94 08:49:37 GMT'),
             throwsFormatException);


### PR DESCRIPTION
## Summary

- resolve RFC 850 two-digit years relative to the current UTC year
- apply RFC 9110's 50-year rollover rule
- add a regression test for the reported 2026 date
- update the API documentation and changelog

## Root cause

`parseHttpDate()` always added 1900 to RFC 850's two-digit year, so `26` was parsed as 1926 regardless of the current year.

## Impact

RFC 850 timestamps such as those used in `Retry-After` headers now resolve to the correct century instead of potentially being treated as expired.

Closes #1939

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test --platform vm`
- `dart test --platform chrome`
- `dart test --platform chrome --compiler dart2wasm`
