### PR TITLE
Switch to feature version bump

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.6.1-wip
+## 1.7.0-wip
 
 * Add `BrowserCredentialsMode` to support the `omit` browser fetch credentials
   mode. Deprecate `withCredentials`.

--- a/pkgs/http/pubspec.yaml
+++ b/pkgs/http/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http
-version: 1.6.1-wip
+version: 1.7.0-wip
 description: A composable, multi-platform, Future-based API for HTTP requests.
 repository: https://github.com/dart-lang/http/tree/master/pkgs/http
 


### PR DESCRIPTION
Use a feature bump for the new API surface area with the
`requestCredentials` optional argument to the `BrowserClient`
constructor.
