### PR TITLE
doc(http_profile): fix broken code examples in header setter docs

### DIFF
--- a/pkgs/http_profile/CHANGELOG.md
+++ b/pkgs/http_profile/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.1.1-wip
 
 * Fixed unintended HTML tags in doc comments. 
+* Fixed the code examples in the `headersListValues` and `headersCommaValues`
+  doc comments.
 
 ## 0.1.0
 

--- a/pkgs/http_profile/lib/src/http_profile_request_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_request_data.dart
@@ -97,7 +97,7 @@ final class HttpProfileRequestData {
   /// // Foo: Bar
   /// // Foo: Baz
   ///
-  /// profile?.requestData.headersListValues({'Foo': ['Bar', 'Baz']});
+  /// profile?.requestData.headersListValues = {'Foo': ['Bar', 'Baz']};
   /// ```
   set headersListValues(Map<String, List<String>>? value) {
     _checkAndUpdate();
@@ -117,7 +117,7 @@ final class HttpProfileRequestData {
   /// // Foo: Bar
   /// // Foo: Baz
   ///
-  /// profile?.requestData.headersCommaValues({'Foo': 'Bar, Baz']});
+  /// profile?.requestData.headersCommaValues = {'Foo': 'Bar, Baz'};
   /// ```
   set headersCommaValues(Map<String, String>? value) {
     _checkAndUpdate();
@@ -134,7 +134,7 @@ final class HttpProfileRequestData {
   /// For example, the map
   ///
   ///  ```dart
-  /// {'Foo': ['Bar', 'Baz']});
+  /// {'Foo': ['Bar', 'Baz']}
   /// ```
   ///
   /// represents the headers

--- a/pkgs/http_profile/lib/src/http_profile_response_data.dart
+++ b/pkgs/http_profile/lib/src/http_profile_response_data.dart
@@ -95,7 +95,7 @@ final class HttpProfileResponseData {
   /// // Foo: Bar
   /// // Foo: Baz
   ///
-  /// profile?.requestData.headersListValues({'Foo': ['Bar', 'Baz']});
+  /// profile?.responseData.headersListValues = {'Foo': ['Bar', 'Baz']};
   /// ```
   set headersListValues(Map<String, List<String>>? value) {
     _checkAndUpdate();
@@ -115,7 +115,7 @@ final class HttpProfileResponseData {
   /// // Foo: Bar
   /// // Foo: Baz
   ///
-  /// profile?.responseData.headersCommaValues({'Foo': 'Bar, Baz']});
+  /// profile?.responseData.headersCommaValues = {'Foo': 'Bar, Baz'};
   /// ```
   set headersCommaValues(Map<String, String>? value) {
     _checkAndUpdate();
@@ -132,7 +132,7 @@ final class HttpProfileResponseData {
   /// For example, the map
   ///
   ///  ```dart
-  /// {'Foo': ['Bar', 'Baz']});
+  /// {'Foo': ['Bar', 'Baz']}
   /// ```
   ///
   /// represents the headers


### PR DESCRIPTION
The four header-setter doc comments in `package:http_profile` contain examples that don't compile, plus one wrong receiver. All verified against the package's own tests, which use the correct form.

### Wrong receiver in the response class

`http_profile_response_data.dart:98` documented `HttpProfileResponseData.headersListValues` with `profile?.requestData...` — copied from the request file. Now `responseData`.

### Setters invoked with call syntax

All four examples called the setters like methods:

```dart
profile?.requestData.headersListValues({'Foo': ['Bar', 'Baz']});
```

`headersListValues` and `headersCommaValues` are setters, so this doesn't compile. The package's tests use assignment — `http_profile_response_data_test.dart:105`:

```dart
profile.responseData.headersListValues = {
```

The examples now match.

### Bracket typos

- `{'Foo': 'Bar, Baz']});` (request:120, response:118) — a `]` closing a `{`.
- The `headers` getter docs showed the bare map as `{'Foo': ['Bar', 'Baz']});` (request:137, response:135) — a stray `);` on what the prose describes as just a map.

Each fixed snippet was checked with `dart format --output=none`: fails to parse before, parses after.

Added a bullet to the existing `0.1.1-wip` CHANGELOG section; no version bump.
