### PR TITLE
Undeprecate the withCredentials field

### DIFF
--- a/pkgs/http/CHANGELOG.md
+++ b/pkgs/http/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.7.0-wip
 
 * Add `BrowserCredentialsMode` to support the `omit` browser fetch credentials
-  mode. Deprecate `withCredentials`.
+  mode. The constructor argument should be preferred over `withCredentials`.
 * Clarified the behavior of response headers in API documentation comments.
 * Make it more clear that `close` must be called for correctness.
 * Replace references to `dart:web` with `package:web` dartdoc.

--- a/pkgs/http/lib/src/browser_client.dart
+++ b/pkgs/http/lib/src/browser_client.dart
@@ -106,7 +106,7 @@ class BrowserClient extends BaseClient {
   ///
   /// Reading this property returns `true` only when [_requestCredentials] is
   /// [RequestCredentials.include].
-  @Deprecated('Use the requestCredentials constructor parameter instead.')
+  // @Deprecated('Use the requestCredentials constructor parameter instead.')
   bool get withCredentials => _requestCredentials == RequestCredentials.include;
 
   /// Whether to send credentials such as cookies or authorization headers for
@@ -117,7 +117,7 @@ class BrowserClient extends BaseClient {
   ///
   /// Setting this to `false` sets [_requestCredentials] to
   /// [RequestCredentials.sameOrigin].
-  @Deprecated('Use the requestCredentials constructor parameter instead.')
+  // @Deprecated('Use the requestCredentials constructor parameter instead.')
   set withCredentials(bool value) {
     _requestCredentials =
         value ? RequestCredentials.include : RequestCredentials.sameOrigin;

--- a/pkgs/http/lib/src/browser_client.dart
+++ b/pkgs/http/lib/src/browser_client.dart
@@ -106,6 +106,7 @@ class BrowserClient extends BaseClient {
   ///
   /// Reading this property returns `true` only when [_requestCredentials] is
   /// [RequestCredentials.include].
+  // TODO(dart-lang/sdk/issues/63975): Deprecate when SDK can tolerate it.
   // @Deprecated('Use the requestCredentials constructor parameter instead.')
   bool get withCredentials => _requestCredentials == RequestCredentials.include;
 
@@ -117,6 +118,7 @@ class BrowserClient extends BaseClient {
   ///
   /// Setting this to `false` sets [_requestCredentials] to
   /// [RequestCredentials.sameOrigin].
+  // TODO(dart-lang/sdk/issues/63975): Deprecate when SDK can tolerate it.
   // @Deprecated('Use the requestCredentials constructor parameter instead.')
   set withCredentials(bool value) {
     _requestCredentials =


### PR DESCRIPTION
Work around some restrictive CI by holding off on the deprecation for
now.
