### PR TITLE
fix(http2): reject requests that exceed `SETTINGS_MAX_CONCURRENT_STREAMS`

### DIFF
--- a/.github/workflows/http2.yaml
+++ b/.github/workflows/http2.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [dev]
+        sdk: [stable]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260

--- a/pkgs/http2/CHANGELOG.md
+++ b/pkgs/http2/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.1-wip
 
 - Gracefully handle receiving headers on a stream that the client has canceled. (#1799)
+- Enforce the locally advertised `SETTINGS_MAX_CONCURRENT_STREAMS` limit on incoming remote streams.
 
 ## 3.0.0
 

--- a/pkgs/http2/lib/src/streams/stream_handler.dart
+++ b/pkgs/http2/lib/src/streams/stream_handler.dart
@@ -542,6 +542,12 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
         ErrorCode.STREAM_CLOSED,
       );
       _closeStreamIdAbnormally(exception.streamId, exception);
+    } on StreamRefusedException catch (exception) {
+      _frameWriter.writeRstStreamFrame(
+        exception.streamId,
+        ErrorCode.REFUSED_STREAM,
+      );
+      _closeStreamIdAbnormally(exception.streamId, exception);
     } on StreamException catch (exception) {
       _frameWriter.writeRstStreamFrame(
         exception.streamId,
@@ -607,6 +613,19 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
 
         if (frame is HeadersFrame) {
           if (isServer) {
+            var localLimit = _localSettings.maxConcurrentStreams;
+            if (localLimit != null) {
+              var activePeerStreams = _openStreams.values
+                  .where((s) => _isPeerInitiatedStream(s.id))
+                  .length;
+              if (activePeerStreams >= localLimit) {
+                throw StreamRefusedException(
+                  frame.header.streamId,
+                  'Refusing remote stream: peer exceeded the locally '
+                  'advertised SETTINGS_MAX_CONCURRENT_STREAMS ($localLimit).',
+                );
+              }
+            }
             var newStream = newRemoteStream(frame.header.streamId);
             _changeState(newStream, StreamState.Open);
 

--- a/pkgs/http2/lib/src/streams/stream_handler.dart
+++ b/pkgs/http2/lib/src/streams/stream_handler.dart
@@ -615,9 +615,10 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
           if (isServer) {
             var localLimit = _localSettings.maxConcurrentStreams;
             if (localLimit != null) {
-              var activePeerStreams = _openStreams.values
-                  .where((s) => _isPeerInitiatedStream(s.id))
-                  .length;
+              var activePeerStreams =
+                  _openStreams.values
+                      .where((s) => _isPeerInitiatedStream(s.id))
+                      .length;
               if (activePeerStreams >= localLimit) {
                 throw StreamRefusedException(
                   frame.header.streamId,

--- a/pkgs/http2/lib/src/streams/stream_handler.dart
+++ b/pkgs/http2/lib/src/streams/stream_handler.dart
@@ -615,6 +615,11 @@ class StreamHandler extends Object with TerminatableMixin, ClosableMixin {
           if (isServer) {
             var localLimit = _localSettings.maxConcurrentStreams;
             if (localLimit != null) {
+              // Enforce our own advertised SETTINGS_MAX_CONCURRENT_STREAMS on
+              // peer-initiated streams. RFC 7540 5.1.2: an endpoint that
+              // receives a HEADERS frame that causes its advertised concurrent
+              // stream limit to be exceeded MUST treat this as a stream error
+              // of type PROTOCOL_ERROR or REFUSED_STREAM.
               var activePeerStreams =
                   _openStreams.values
                       .where((s) => _isPeerInitiatedStream(s.id))

--- a/pkgs/http2/lib/src/sync_errors.dart
+++ b/pkgs/http2/lib/src/sync_errors.dart
@@ -55,6 +55,6 @@ class StreamRefusedException extends StreamException {
   StreamRefusedException(super.streamId, [super.message = '']);
 
   @override
-  String toString() => 'StreamRefusedException(stream id: $streamId): $_message';
+  String toString() =>
+      'StreamRefusedException(stream id: $streamId): $_message';
 }
-

--- a/pkgs/http2/lib/src/sync_errors.dart
+++ b/pkgs/http2/lib/src/sync_errors.dart
@@ -50,3 +50,11 @@ class StreamClosedException extends StreamException {
   @override
   String toString() => 'StreamClosedException(stream id: $streamId): $_message';
 }
+
+class StreamRefusedException extends StreamException {
+  StreamRefusedException(super.streamId, [super.message = '']);
+
+  @override
+  String toString() => 'StreamRefusedException(stream id: $streamId): $_message';
+}
+

--- a/pkgs/http2/test/server_test.dart
+++ b/pkgs/http2/test/server_test.dart
@@ -217,8 +217,91 @@ void main() {
         await Future.wait([serverFun(), clientFun()]);
       });
     });
+
+    group('max-concurrent-streams', () {
+      test('exceeding-max-concurrent-streams', () async {
+        var writeA = StreamController<List<int>>();
+        var writeB = StreamController<List<int>>();
+
+        var server = ServerTransportConnection.viaStreams(
+          writeB.stream,
+          writeA,
+          settings: const ServerSettings(concurrentStreamLimit: 2),
+        );
+
+        var localSettings = ActiveSettings();
+        var clientReader = StreamIterator(
+          FrameReader(writeA.stream, localSettings).startDecoding(),
+        );
+
+        Future<Frame> nextFrame() async {
+          expect(await clientReader.moveNext(), true);
+          return clientReader.current;
+        }
+
+        var encoder = HPackEncoder();
+        var peerSettings = ActiveSettings();
+        writeB.add(CONNECTION_PREFACE);
+        var clientWriter = FrameWriter(encoder, writeB, peerSettings);
+
+        var clientDone = Completer<void>();
+
+        Future serverFun() async {
+          var incoming = <ServerTransportStream>[];
+          var subscription = server.incomingStreams.listen(incoming.add);
+
+          await clientDone.future;
+
+          expect(incoming.length, 2);
+          await subscription.cancel();
+          await server.terminate();
+        }
+
+        Future clientFun() async {
+          expect(await nextFrame() is SettingsFrame, true);
+          clientWriter.writeSettingsAckFrame();
+          clientWriter.writeSettingsFrame([]);
+          expect(await nextFrame() is SettingsFrame, true);
+
+          clientWriter.writeHeadersFrame(1, [
+            Header.ascii('a', 'b'),
+          ], endStream: false);
+          clientWriter.writeHeadersFrame(3, [
+            Header.ascii('a', 'b'),
+          ], endStream: false);
+          clientWriter.writeHeadersFrame(5, [
+            Header.ascii('a', 'b'),
+          ], endStream: false);
+
+          var frame = await nextFrame();
+          expect(
+            frame,
+            isA<RstStreamFrame>()
+                .having(
+                  (f) => f.errorCode,
+                  'errorCode',
+                  ErrorCode.REFUSED_STREAM,
+                )
+                .having((f) => f.header.streamId, 'header.streamId', 5),
+          );
+
+          clientDone.complete();
+
+          var hasGoaway = await clientReader.moveNext();
+          expect(hasGoaway, true);
+          expect(clientReader.current is GoawayFrame, true);
+
+          var closed = await clientReader.moveNext();
+          expect(closed, false);
+        }
+
+        await Future.wait([serverFun(), clientFun()]);
+      });
+    });
   });
 }
+
+
 
 void serverTest(
   String name,

--- a/pkgs/http2/test/server_test.dart
+++ b/pkgs/http2/test/server_test.dart
@@ -295,7 +295,7 @@ void main() {
           expect(closed, false);
         }
 
-        await Future.wait([serverFun(), clientFun()]);
+        await [serverFun(), clientFun()].wait;
       });
     });
   });

--- a/pkgs/http2/test/server_test.dart
+++ b/pkgs/http2/test/server_test.dart
@@ -301,8 +301,6 @@ void main() {
   });
 }
 
-
-
 void serverTest(
   String name,
   void Function(


### PR DESCRIPTION
1. Return `REFUSED_STREAM` if the peer requests more peers then were advertised in `SETTINGS_MAX_CONCURRENT_STREAMS`. This is a requirement according to RFC-7540 5.1.2.
2. Modify the tests/format/etc. to run with the stable version of Dart - the dev and stable versions of Dart currently disagree on formatting.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
