### PR TITLE
Fix #1972: bypass body-reading for HEAD requests in io_client

### DIFF
--- a/pkgs/http/lib/src/io_client.dart
+++ b/pkgs/http/lib/src/io_client.dart
@@ -157,6 +157,34 @@ class IOClient extends BaseClient {
       final response = await stream.pipe(ioRequest) as HttpClientResponse;
       hasResponse = true;
 
+      if (request.method.toUpperCase() == 'HEAD') {
+        unawaited(response.drain<void>().catchError((_) {}));
+
+        var headers = <String, String>{};
+        response.headers.forEach((key, values) {
+          // TODO: Remove trimRight() when
+          // https://github.com/dart-lang/sdk/issues/53005 is resolved and the
+          // package:http SDK constraint requires that version or later.
+          headers[key] = values.map((value) => value.trimRight()).join(',');
+        });
+
+        return _IOStreamedResponseV2(
+          const Stream<List<int>>.empty(),
+          response.statusCode,
+          contentLength:
+              response.contentLength == -1 ? null : response.contentLength,
+          request: request,
+          headers: headers,
+          isRedirect: response.isRedirect,
+          url: response.redirects.isNotEmpty
+              ? response.redirects.last.location
+              : request.url,
+          persistentConnection: response.persistentConnection,
+          reasonPhrase: response.reasonPhrase,
+          inner: response,
+        );
+      }
+
       StreamSubscription<List<int>>? ioResponseSubscription;
       late final StreamController<List<int>> responseController;
       var responseListenStarted = false;


### PR DESCRIPTION
Fixes #1972

This PR resolves an issue where `HEAD` requests unexpectedly throw a `ClientException` due to a mismatch between the `Content-Length` header and the actual response body length (which is naturally empty for `HEAD` requests).

Because `dart:io`'s `HttpClient` will sometimes fail when verifying the `Content-Length` of an empty `HEAD` response body, we now intercept `HEAD` requests in `io_client.dart`. Instead of attempting to read the body stream, we asynchronously drain the underlying connection (safely swallowing any spurious `dart:io` length-mismatch exceptions) and immediately return the headers with a safe, empty stream. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
