### PR TITLE
fix(http2): bound header size to 256 KiB

### DIFF
--- a/pkgs/http2/CHANGELOG.md
+++ b/pkgs/http2/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Gracefully handle receiving headers on a stream that the client has canceled. (#1799)
 - Treat incoming server push streams as connection protocol error when pushes are disabled (SETTINGS_ENABLE_PUSH=0).
 - Enforce the locally advertised `SETTINGS_MAX_CONCURRENT_STREAMS` limit on incoming remote streams.
-- Limit accumulated header block size to 256 KiB during frame defragmentation to prevent unbounded CONTINUATION-frame buffering.
+- Add `maxHeaderListSize` setting to `ClientSettings` and `ServerSettings` (defaulting to 256 KiB), advertise `SETTINGS_MAX_HEADER_LIST_SIZE`, enforce it during HPACK decoding, and limit CONTINUATION frame buffering with $O(N)$ defragmentation.
 
 ## 3.0.0
 

--- a/pkgs/http2/CHANGELOG.md
+++ b/pkgs/http2/CHANGELOG.md
@@ -3,7 +3,10 @@
 - Gracefully handle receiving headers on a stream that the client has canceled. (#1799)
 - Treat incoming server push streams as connection protocol error when pushes are disabled (SETTINGS_ENABLE_PUSH=0).
 - Enforce the locally advertised `SETTINGS_MAX_CONCURRENT_STREAMS` limit on incoming remote streams.
-- Add `maxHeaderListSize` setting to `ClientSettings` and `ServerSettings` (defaulting to 256 KiB), advertise `SETTINGS_MAX_HEADER_LIST_SIZE`, enforce it during HPACK decoding, and limit CONTINUATION frame buffering with $O(N)$ defragmentation.
+- Add `maxHeaderListSize` setting to `ClientSettings` and `ServerSettings`
+  (defaulting to 256 KiB), advertise `SETTINGS_MAX_HEADER_LIST_SIZE`, enforce
+  it during HPACK decoding, and limit CONTINUATION frame buffering with $O(N)$
+  defragmentation.
 
 ## 3.0.0
 

--- a/pkgs/http2/CHANGELOG.md
+++ b/pkgs/http2/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Gracefully handle receiving headers on a stream that the client has canceled. (#1799)
 - Treat incoming server push streams as connection protocol error when pushes are disabled (SETTINGS_ENABLE_PUSH=0).
 - Enforce the locally advertised `SETTINGS_MAX_CONCURRENT_STREAMS` limit on incoming remote streams.
+- Limit accumulated header block size to 256 KiB during frame defragmentation to prevent unbounded CONTINUATION-frame buffering.
 
 ## 3.0.0
 

--- a/pkgs/http2/lib/src/connection.dart
+++ b/pkgs/http2/lib/src/connection.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert' show utf8;
+import 'dart:math' show max;
 
 import '../transport.dart';
 import 'connection_preface.dart';
@@ -167,8 +168,12 @@ abstract class Connection {
     var maxHeaderListSize =
         settingsObject.maxHeaderListSize ??
         FrameDefragmenter.defaultMaxAccumulatedHeaderBlockBytes;
+    var maxAccumulatedHeaderBlockBytes = max(
+      maxHeaderListSize,
+      FrameDefragmenter.defaultMaxAccumulatedHeaderBlockBytes,
+    );
     _hpackContext = HPackContext(maxHeaderListSize: maxHeaderListSize);
-    _defragmenter = FrameDefragmenter(maxHeaderListSize);
+    _defragmenter = FrameDefragmenter(maxAccumulatedHeaderBlockBytes);
 
     // Setup frame reading.
     var incomingFrames =
@@ -288,12 +293,12 @@ abstract class Connection {
       );
     }
 
-    var maxHeaderListSize = settings.maxHeaderListSize;
-    if (maxHeaderListSize != null) {
-      settingsList.add(
-        Setting(Setting.SETTINGS_MAX_HEADER_LIST_SIZE, maxHeaderListSize),
-      );
-    }
+    var maxHeaderListSize =
+        settings.maxHeaderListSize ??
+        FrameDefragmenter.defaultMaxAccumulatedHeaderBlockBytes;
+    settingsList.add(
+      Setting(Setting.SETTINGS_MAX_HEADER_LIST_SIZE, maxHeaderListSize),
+    );
 
     if (settings is ClientSettings) {
       // By default the server is allowed to do server pushes.

--- a/pkgs/http2/lib/src/connection.dart
+++ b/pkgs/http2/lib/src/connection.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert' show utf8;
-import 'dart:math' show max;
 
 import '../transport.dart';
 import 'connection_preface.dart';
@@ -168,12 +167,8 @@ abstract class Connection {
     var maxHeaderListSize =
         settingsObject.maxHeaderListSize ??
         FrameDefragmenter.defaultMaxAccumulatedHeaderBlockBytes;
-    var maxAccumulatedHeaderBlockBytes = max(
-      maxHeaderListSize,
-      FrameDefragmenter.defaultMaxAccumulatedHeaderBlockBytes,
-    );
     _hpackContext = HPackContext(maxHeaderListSize: maxHeaderListSize);
-    _defragmenter = FrameDefragmenter(maxAccumulatedHeaderBlockBytes);
+    _defragmenter = FrameDefragmenter(maxHeaderListSize);
 
     // Setup frame reading.
     var incomingFrames =

--- a/pkgs/http2/lib/src/connection.dart
+++ b/pkgs/http2/lib/src/connection.dart
@@ -109,7 +109,7 @@ abstract class Connection {
       _onInitialPeerSettingsReceived.future;
 
   /// The HPack context for this connection.
-  final HPackContext _hpackContext = HPackContext();
+  late final HPackContext _hpackContext;
 
   /// The flow window for this connection of the peer.
   final Window _peerWindow = Window();
@@ -118,7 +118,7 @@ abstract class Connection {
   final Window _localWindow = Window();
 
   /// Used for defragmenting PushPromise/Header frames.
-  final FrameDefragmenter _defragmenter = FrameDefragmenter();
+  late final FrameDefragmenter _defragmenter;
 
   /// The outgoing frames of this connection;
   late FrameWriter _frameWriter;
@@ -164,6 +164,12 @@ abstract class Connection {
     StreamSink<List<int>> outgoing,
     Settings settingsObject,
   ) {
+    var maxHeaderListSize =
+        settingsObject.maxHeaderListSize ??
+        FrameDefragmenter.defaultMaxAccumulatedHeaderBlockBytes;
+    _hpackContext = HPackContext(maxHeaderListSize: maxHeaderListSize);
+    _defragmenter = FrameDefragmenter(maxHeaderListSize);
+
     // Setup frame reading.
     var incomingFrames =
         FrameReader(incoming, acknowledgedSettings).startDecoding();
@@ -279,6 +285,13 @@ abstract class Connection {
     if (streamWindowSize != null) {
       settingsList.add(
         Setting(Setting.SETTINGS_INITIAL_WINDOW_SIZE, streamWindowSize),
+      );
+    }
+
+    var maxHeaderListSize = settings.maxHeaderListSize;
+    if (maxHeaderListSize != null) {
+      settingsList.add(
+        Setting(Setting.SETTINGS_MAX_HEADER_LIST_SIZE, maxHeaderListSize),
       );
     }
 

--- a/pkgs/http2/lib/src/frames/frame_defragmenter.dart
+++ b/pkgs/http2/lib/src/frames/frame_defragmenter.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import '../sync_errors.dart';
 
 import 'frames.dart';
@@ -13,13 +15,23 @@ class FrameDefragmenter {
   /// withholds END_HEADERS could otherwise send unbounded CONTINUATION frames
   /// and exhaust memory. 256 KiB is far above any legitimate header block but
   /// small enough to bound per-connection buffering.
-  static const int _maxAccumulatedHeaderBlockBytes = 256 * 1024;
+  static const int defaultMaxAccumulatedHeaderBlockBytes = 256 * 1024;
+
+  final int maxAccumulatedHeaderBlockBytes;
 
   /// The current incomplete [HeadersFrame] fragment.
   HeadersFrame? _headersFrame;
 
   /// The current incomplete [PushPromiseFrame] fragment.
   PushPromiseFrame? _pushPromiseFrame;
+
+  BytesBuilder _builder = BytesBuilder(copy: false);
+  int _accumulatedFlags = 0;
+  int _accumulatedLength = 0;
+
+  FrameDefragmenter([
+    this.maxAccumulatedHeaderBlockBytes = defaultMaxAccumulatedHeaderBlockBytes,
+  ]);
 
   /// Tries to defragment [frame].
   ///
@@ -38,21 +50,41 @@ class FrameDefragmenter {
     if (_headersFrame != null) {
       if (frame is ContinuationFrame) {
         if (_headersFrame!.header.streamId != frame.header.streamId) {
+          _headersFrame = null;
+          _builder.clear();
           throw ProtocolException(
             'Defragmentation: frames have different stream ids.',
           );
         }
-        _headersFrame = _headersFrame!.addBlockContinuation(frame);
-        _checkAccumulatedSize(_headersFrame!.headerBlockFragment.length);
+        _builder.add(frame.headerBlockFragment);
+        _accumulatedFlags |= frame.header.flags;
+        _accumulatedLength += frame.headerBlockFragment.length;
+        _checkAccumulatedSize(_builder.length);
 
         if (frame.hasEndHeadersFlag) {
-          var frame = _headersFrame;
+          var savedHeaders = _headersFrame!;
           _headersFrame = null;
-          return frame;
+          var finalData = _builder.takeBytes();
+          var fh = FrameHeader(
+            _accumulatedLength,
+            savedHeaders.header.type,
+            _accumulatedFlags,
+            savedHeaders.header.streamId,
+          );
+          return HeadersFrame(
+            fh,
+            savedHeaders.padLength,
+            savedHeaders.exclusiveDependency,
+            savedHeaders.streamDependency,
+            savedHeaders.weight,
+            finalData,
+          );
         } else {
           return null;
         }
       } else {
+        _headersFrame = null;
+        _builder.clear();
         throw ProtocolException(
           'Defragmentation: Incomplete frame must be followed by '
           'continuation frame.',
@@ -61,21 +93,39 @@ class FrameDefragmenter {
     } else if (_pushPromiseFrame != null) {
       if (frame is ContinuationFrame) {
         if (_pushPromiseFrame!.header.streamId != frame.header.streamId) {
+          _pushPromiseFrame = null;
+          _builder.clear();
           throw ProtocolException(
             'Defragmentation: frames have different stream ids.',
           );
         }
-        _pushPromiseFrame = _pushPromiseFrame!.addBlockContinuation(frame);
-        _checkAccumulatedSize(_pushPromiseFrame!.headerBlockFragment.length);
+        _builder.add(frame.headerBlockFragment);
+        _accumulatedFlags |= frame.header.flags;
+        _accumulatedLength += frame.headerBlockFragment.length;
+        _checkAccumulatedSize(_builder.length);
 
         if (frame.hasEndHeadersFlag) {
-          var frame = _pushPromiseFrame;
+          var savedPushPromise = _pushPromiseFrame!;
           _pushPromiseFrame = null;
-          return frame;
+          var finalData = _builder.takeBytes();
+          var fh = FrameHeader(
+            _accumulatedLength,
+            savedPushPromise.header.type,
+            _accumulatedFlags,
+            savedPushPromise.header.streamId,
+          );
+          return PushPromiseFrame(
+            fh,
+            savedPushPromise.padLength,
+            savedPushPromise.promisedStreamId,
+            finalData,
+          );
         } else {
           return null;
         }
       } else {
+        _pushPromiseFrame = null;
+        _builder.clear();
         throw ProtocolException(
           'Defragmentation: Incomplete frame must be followed by '
           'continuation frame.',
@@ -84,12 +134,22 @@ class FrameDefragmenter {
     } else {
       if (frame is HeadersFrame) {
         if (!frame.hasEndHeadersFlag) {
+          _checkAccumulatedSize(frame.headerBlockFragment.length);
           _headersFrame = frame;
+          _builder = BytesBuilder(copy: false);
+          _builder.add(frame.headerBlockFragment);
+          _accumulatedFlags = frame.header.flags;
+          _accumulatedLength = frame.header.length;
           return null;
         }
       } else if (frame is PushPromiseFrame) {
         if (!frame.hasEndHeadersFlag) {
+          _checkAccumulatedSize(frame.headerBlockFragment.length);
           _pushPromiseFrame = frame;
+          _builder = BytesBuilder(copy: false);
+          _builder.add(frame.headerBlockFragment);
+          _accumulatedFlags = frame.header.flags;
+          _accumulatedLength = frame.header.length;
           return null;
         }
       }
@@ -101,12 +161,13 @@ class FrameDefragmenter {
   }
 
   void _checkAccumulatedSize(int accumulatedBytes) {
-    if (accumulatedBytes > _maxAccumulatedHeaderBlockBytes) {
+    if (accumulatedBytes > maxAccumulatedHeaderBlockBytes) {
       _headersFrame = null;
       _pushPromiseFrame = null;
+      _builder.clear();
       throw ProtocolException(
         'Defragmentation: accumulated header block exceeds '
-        '$_maxAccumulatedHeaderBlockBytes bytes.',
+        '$maxAccumulatedHeaderBlockBytes bytes.',
       );
     }
   }

--- a/pkgs/http2/lib/src/frames/frame_defragmenter.dart
+++ b/pkgs/http2/lib/src/frames/frame_defragmenter.dart
@@ -19,13 +19,10 @@ class FrameDefragmenter {
 
   final int maxAccumulatedHeaderBlockBytes;
 
-  /// The current incomplete [HeadersFrame] fragment.
-  HeadersFrame? _headersFrame;
+  /// The current incomplete [HeadersFrame] or [PushPromiseFrame].
+  Frame? _incompleteFrame;
 
-  /// The current incomplete [PushPromiseFrame] fragment.
-  PushPromiseFrame? _pushPromiseFrame;
-
-  BytesBuilder _builder = BytesBuilder(copy: false);
+  final BytesBuilder _builder = BytesBuilder(copy: false);
   int _accumulatedFlags = 0;
   int _accumulatedLength = 0;
 
@@ -47,11 +44,10 @@ class FrameDefragmenter {
   // TODO: Consider handling continuation frames without preceding
   // headers/push-promise frame here instead of the call site?
   Frame? tryDefragmentFrame(Frame? frame) {
-    if (_headersFrame != null) {
+    if (_incompleteFrame != null) {
       if (frame is ContinuationFrame) {
-        if (_headersFrame!.header.streamId != frame.header.streamId) {
-          _headersFrame = null;
-          _builder.clear();
+        if (_incompleteFrame!.header.streamId != frame.header.streamId) {
+          _reset();
           throw ProtocolException(
             'Defragmentation: frames have different stream ids.',
           );
@@ -62,96 +58,50 @@ class FrameDefragmenter {
         _checkAccumulatedSize(_builder.length);
 
         if (frame.hasEndHeadersFlag) {
-          var savedHeaders = _headersFrame!;
-          _headersFrame = null;
+          var saved = _incompleteFrame!;
           var finalData = _builder.takeBytes();
           var fh = FrameHeader(
             _accumulatedLength,
-            savedHeaders.header.type,
+            saved.header.type,
             _accumulatedFlags,
-            savedHeaders.header.streamId,
+            saved.header.streamId,
           );
-          return HeadersFrame(
-            fh,
-            savedHeaders.padLength,
-            savedHeaders.exclusiveDependency,
-            savedHeaders.streamDependency,
-            savedHeaders.weight,
-            finalData,
-          );
-        } else {
-          return null;
-        }
-      } else {
-        _headersFrame = null;
-        _builder.clear();
-        throw ProtocolException(
-          'Defragmentation: Incomplete frame must be followed by '
-          'continuation frame.',
-        );
-      }
-    } else if (_pushPromiseFrame != null) {
-      if (frame is ContinuationFrame) {
-        if (_pushPromiseFrame!.header.streamId != frame.header.streamId) {
-          _pushPromiseFrame = null;
-          _builder.clear();
-          throw ProtocolException(
-            'Defragmentation: frames have different stream ids.',
-          );
-        }
-        _builder.add(frame.headerBlockFragment);
-        _accumulatedFlags |= frame.header.flags;
-        _accumulatedLength += frame.headerBlockFragment.length;
-        _checkAccumulatedSize(_builder.length);
+          _reset();
 
-        if (frame.hasEndHeadersFlag) {
-          var savedPushPromise = _pushPromiseFrame!;
-          _pushPromiseFrame = null;
-          var finalData = _builder.takeBytes();
-          var fh = FrameHeader(
-            _accumulatedLength,
-            savedPushPromise.header.type,
-            _accumulatedFlags,
-            savedPushPromise.header.streamId,
-          );
-          return PushPromiseFrame(
-            fh,
-            savedPushPromise.padLength,
-            savedPushPromise.promisedStreamId,
-            finalData,
-          );
+          if (saved is HeadersFrame) {
+            return HeadersFrame(
+              fh,
+              saved.padLength,
+              saved.exclusiveDependency,
+              saved.streamDependency,
+              saved.weight,
+              finalData,
+            );
+          } else if (saved is PushPromiseFrame) {
+            return PushPromiseFrame(
+              fh,
+              saved.padLength,
+              saved.promisedStreamId,
+              finalData,
+            );
+          }
         } else {
           return null;
         }
       } else {
-        _pushPromiseFrame = null;
-        _builder.clear();
+        _reset();
         throw ProtocolException(
           'Defragmentation: Incomplete frame must be followed by '
           'continuation frame.',
         );
       }
     } else {
-      if (frame is HeadersFrame) {
-        if (!frame.hasEndHeadersFlag) {
-          _checkAccumulatedSize(frame.headerBlockFragment.length);
-          _headersFrame = frame;
-          _builder = BytesBuilder(copy: false);
-          _builder.add(frame.headerBlockFragment);
-          _accumulatedFlags = frame.header.flags;
-          _accumulatedLength = frame.header.length;
-          return null;
-        }
-      } else if (frame is PushPromiseFrame) {
-        if (!frame.hasEndHeadersFlag) {
-          _checkAccumulatedSize(frame.headerBlockFragment.length);
-          _pushPromiseFrame = frame;
-          _builder = BytesBuilder(copy: false);
-          _builder.add(frame.headerBlockFragment);
-          _accumulatedFlags = frame.header.flags;
-          _accumulatedLength = frame.header.length;
-          return null;
-        }
+      if (frame is HeadersFrame && !frame.hasEndHeadersFlag) {
+        _startDefragmentation(frame, frame.headerBlockFragment);
+        return null;
+      } else if (frame is PushPromiseFrame && !frame.hasEndHeadersFlag) {
+        _startDefragmentation(frame, frame.headerBlockFragment);
+        return null;
       }
     }
 
@@ -160,15 +110,28 @@ class FrameDefragmenter {
     return frame;
   }
 
+  void _startDefragmentation(Frame frame, List<int> initialFragment) {
+    _checkAccumulatedSize(initialFragment.length);
+    _incompleteFrame = frame;
+    _builder.add(initialFragment);
+    _accumulatedFlags = frame.header.flags;
+    _accumulatedLength = frame.header.length;
+  }
+
   void _checkAccumulatedSize(int accumulatedBytes) {
     if (accumulatedBytes > maxAccumulatedHeaderBlockBytes) {
-      _headersFrame = null;
-      _pushPromiseFrame = null;
-      _builder.clear();
+      _reset();
       throw ProtocolException(
         'Defragmentation: accumulated header block exceeds '
         '$maxAccumulatedHeaderBlockBytes bytes.',
       );
     }
+  }
+
+  void _reset() {
+    _incompleteFrame = null;
+    _builder.clear();
+    _accumulatedFlags = 0;
+    _accumulatedLength = 0;
   }
 }

--- a/pkgs/http2/lib/src/frames/frame_defragmenter.dart
+++ b/pkgs/http2/lib/src/frames/frame_defragmenter.dart
@@ -7,9 +7,14 @@ import '../sync_errors.dart';
 import 'frames.dart';
 
 /// Class used for defragmenting [HeadersFrame]s and [PushPromiseFrame]s.
-// TODO: Somehow emit an error if too many continuation frames have been sent
-// (since we're buffering all of them).
 class FrameDefragmenter {
+  /// Maximum total size, in bytes, of a header block accumulated across a
+  /// HEADERS/PUSH_PROMISE frame and its CONTINUATION frames. A peer that
+  /// withholds END_HEADERS could otherwise send unbounded CONTINUATION frames
+  /// and exhaust memory. 256 KiB is far above any legitimate header block but
+  /// small enough to bound per-connection buffering.
+  static const int _maxAccumulatedHeaderBlockBytes = 256 * 1024;
+
   /// The current incomplete [HeadersFrame] fragment.
   HeadersFrame? _headersFrame;
 
@@ -38,6 +43,7 @@ class FrameDefragmenter {
           );
         }
         _headersFrame = _headersFrame!.addBlockContinuation(frame);
+        _checkAccumulatedSize(_headersFrame!.headerBlockFragment.length);
 
         if (frame.hasEndHeadersFlag) {
           var frame = _headersFrame;
@@ -60,6 +66,7 @@ class FrameDefragmenter {
           );
         }
         _pushPromiseFrame = _pushPromiseFrame!.addBlockContinuation(frame);
+        _checkAccumulatedSize(_pushPromiseFrame!.headerBlockFragment.length);
 
         if (frame.hasEndHeadersFlag) {
           var frame = _pushPromiseFrame;
@@ -91,5 +98,16 @@ class FrameDefragmenter {
     // If this frame is not relevant for header defragmentation, we pass it to
     // the next stage.
     return frame;
+  }
+
+  void _checkAccumulatedSize(int accumulatedBytes) {
+    if (accumulatedBytes > _maxAccumulatedHeaderBlockBytes) {
+      _headersFrame = null;
+      _pushPromiseFrame = null;
+      throw ProtocolException(
+        'Defragmentation: accumulated header block exceeds '
+        '$_maxAccumulatedHeaderBlockBytes bytes.',
+      );
+    }
   }
 }

--- a/pkgs/http2/lib/src/frames/frame_types.dart
+++ b/pkgs/http2/lib/src/frames/frame_types.dart
@@ -120,42 +120,6 @@ class HeadersFrame extends Frame {
   bool get hasPaddedFlag => _isFlagSet(header.flags, FLAG_PADDED);
   bool get hasPriorityFlag => _isFlagSet(header.flags, FLAG_PRIORITY);
 
-  HeadersFrame addBlockContinuation(ContinuationFrame frame) {
-    var fragment = frame.headerBlockFragment;
-    var flags = header.flags | frame.header.flags;
-    var fh = FrameHeader(
-      header.length + fragment.length,
-      header.type,
-      flags,
-      header.streamId,
-    );
-
-    var mergedHeaderBlockFragment = Uint8List(
-      headerBlockFragment.length + fragment.length,
-    );
-
-    mergedHeaderBlockFragment.setRange(
-      0,
-      headerBlockFragment.length,
-      headerBlockFragment,
-    );
-
-    mergedHeaderBlockFragment.setRange(
-      headerBlockFragment.length,
-      mergedHeaderBlockFragment.length,
-      fragment,
-    );
-
-    return HeadersFrame(
-      fh,
-      padLength,
-      exclusiveDependency,
-      streamDependency,
-      weight,
-      mergedHeaderBlockFragment,
-    );
-  }
-
   @override
   Map toJson() =>
       super.toJson()..addAll({
@@ -259,40 +223,6 @@ class PushPromiseFrame extends Frame {
 
   bool get hasEndHeadersFlag => _isFlagSet(header.flags, FLAG_END_HEADERS);
   bool get hasPaddedFlag => _isFlagSet(header.flags, FLAG_PADDED);
-
-  PushPromiseFrame addBlockContinuation(ContinuationFrame frame) {
-    var fragment = frame.headerBlockFragment;
-    var flags = header.flags | frame.header.flags;
-    var fh = FrameHeader(
-      header.length + fragment.length,
-      header.type,
-      flags,
-      header.streamId,
-    );
-
-    var mergedHeaderBlockFragment = Uint8List(
-      headerBlockFragment.length + fragment.length,
-    );
-
-    mergedHeaderBlockFragment.setRange(
-      0,
-      headerBlockFragment.length,
-      headerBlockFragment,
-    );
-
-    mergedHeaderBlockFragment.setRange(
-      headerBlockFragment.length,
-      mergedHeaderBlockFragment.length,
-      fragment,
-    );
-
-    return PushPromiseFrame(
-      fh,
-      padLength,
-      promisedStreamId,
-      mergedHeaderBlockFragment,
-    );
-  }
 
   @override
   Map toJson() =>

--- a/pkgs/http2/lib/src/hpack/hpack.dart
+++ b/pkgs/http2/lib/src/hpack/hpack.dart
@@ -29,12 +29,13 @@ class HPackDecodingException implements Exception {
 /// This is a statefull class, so encoding/decoding changes internal state.
 class HPackContext {
   final HPackEncoder encoder = HPackEncoder();
-  final HPackDecoder decoder = HPackDecoder();
+  final HPackDecoder decoder;
 
   HPackContext({
     int maxSendingHeaderTableSize = 4096,
     int maxReceivingHeaderTableSize = 4096,
-  }) {
+    int? maxHeaderListSize,
+  }) : decoder = HPackDecoder(maxHeaderListSize: maxHeaderListSize) {
     encoder.updateMaxSendingHeaderTableSize(maxSendingHeaderTableSize);
     decoder.updateMaxReceivingHeaderTableSize(maxReceivingHeaderTableSize);
   }
@@ -58,9 +59,12 @@ class Header {
 
 /// A stateful HPACK decoder.
 class HPackDecoder {
+  final int? maxHeaderListSize;
   late int _maxHeaderTableSize;
 
   final IndexTable _table = IndexTable();
+
+  HPackDecoder({this.maxHeaderListSize});
 
   void updateMaxReceivingHeaderTableSize(int newMaximumSize) {
     _maxHeaderTableSize = newMaximumSize;
@@ -121,6 +125,21 @@ class HPackDecoder {
 
     try {
       var headers = <Header>[];
+      var totalHeaderListSize = 0;
+
+      void addHeader(Header header) {
+        headers.add(header);
+        if (maxHeaderListSize != null) {
+          totalHeaderListSize += header.name.length + header.value.length + 32;
+          if (totalHeaderListSize > maxHeaderListSize!) {
+            throw HPackDecodingException(
+              'Header list size exceeds maximum allowed size of '
+              '$maxHeaderListSize octets.',
+            );
+          }
+        }
+      }
+
       while (offset < data.length) {
         var byte = data[offset];
         var isIndexedField = (byte & 0x80) != 0;
@@ -133,15 +152,15 @@ class HPackDecoder {
         if (isIndexedField) {
           var index = readInteger(7);
           var field = _table.lookup(index);
-          headers.add(field);
+          addHeader(field);
         } else if (isIncrementalIndexing) {
           var field = readHeaderFieldInternal(readInteger(6));
           _table.addHeaderField(field);
-          headers.add(field);
+          addHeader(field);
         } else if (isWithoutIndexing) {
-          headers.add(readHeaderFieldInternal(readInteger(4)));
+          addHeader(readHeaderFieldInternal(readInteger(4)));
         } else if (isNeverIndexing) {
-          headers.add(
+          addHeader(
             readHeaderFieldInternal(readInteger(4), neverIndexed: true),
           );
         } else if (isDynamicTableSizeUpdate) {

--- a/pkgs/http2/lib/transport.dart
+++ b/pkgs/http2/lib/transport.dart
@@ -23,12 +23,24 @@ abstract class Settings {
   /// streams (defaults to 65535 bytes).
   final int? streamWindowSize;
 
-  const Settings({this.concurrentStreamLimit, this.streamWindowSize});
+  /// The maximum size of header list that the sender is prepared to accept, in
+  /// bytes (defaults to 256 KiB, which is the value used by Chrome 152).
+  final int? maxHeaderListSize;
+
+  const Settings({
+    this.concurrentStreamLimit,
+    this.streamWindowSize,
+    this.maxHeaderListSize,
+  });
 }
 
 /// Settings for a [TransportConnection] a server can make.
 class ServerSettings extends Settings {
-  const ServerSettings({super.concurrentStreamLimit, super.streamWindowSize});
+  const ServerSettings({
+    super.concurrentStreamLimit,
+    super.streamWindowSize,
+    super.maxHeaderListSize,
+  });
 }
 
 /// Settings for a [TransportConnection] a client can make.
@@ -39,6 +51,7 @@ class ClientSettings extends Settings {
   const ClientSettings({
     super.concurrentStreamLimit,
     super.streamWindowSize,
+    super.maxHeaderListSize,
     this.allowServerPushes = false,
   });
 }

--- a/pkgs/http2/lib/transport.dart
+++ b/pkgs/http2/lib/transport.dart
@@ -24,7 +24,8 @@ abstract class Settings {
   final int? streamWindowSize;
 
   /// The maximum size of header list that the sender is prepared to accept, in
-  /// bytes (defaults to 256 KiB, which is the value used by Chrome 152).
+  /// bytes (defaults to 256 KiB, which is the value used by Chrome and
+  /// Firefox).
   final int? maxHeaderListSize;
 
   const Settings({

--- a/pkgs/http2/test/client_test.dart
+++ b/pkgs/http2/test/client_test.dart
@@ -64,6 +64,43 @@ void main() {
 
         await Future.wait([serverFun(), clientFun()]);
       });
+
+      clientTest('client-advertises-max-header-list-size', (
+        ClientTransportConnection client,
+        FrameWriter serverWriter,
+        StreamIterator<Frame> serverReader,
+        Future<Frame> Function() nextFrame,
+      ) async {
+        var settingsDone = Completer<void>();
+
+        Future serverFun() async {
+          serverWriter.writeSettingsFrame([]);
+          var frame = await nextFrame() as SettingsFrame;
+          var setting = frame.settings.firstWhere(
+            (s) => s.identifier == Setting.SETTINGS_MAX_HEADER_LIST_SIZE,
+          );
+          expect(setting.value, 128 * 1024);
+          serverWriter.writeSettingsAckFrame();
+          expect(await nextFrame(), isA<SettingsFrame>());
+          settingsDone.complete();
+          expect(
+            await nextFrame(),
+            isA<GoawayFrame>().having(
+              (f) => f.errorCode,
+              'errorCode',
+              ErrorCode.NO_ERROR,
+            ),
+          );
+          expect(await serverReader.moveNext(), false);
+        }
+
+        Future clientFun() async {
+          await settingsDone.future;
+          await client.finish();
+        }
+
+        await Future.wait([serverFun(), clientFun()]);
+      }, settings: const ClientSettings(maxHeaderListSize: 128 * 1024));
     });
 
     group('connection-operational', () {

--- a/pkgs/http2/test/client_test.dart
+++ b/pkgs/http2/test/client_test.dart
@@ -101,6 +101,43 @@ void main() {
 
         await Future.wait([serverFun(), clientFun()]);
       }, settings: const ClientSettings(maxHeaderListSize: 128 * 1024));
+
+      clientTest('client-advertises-default-max-header-list-size', (
+        ClientTransportConnection client,
+        FrameWriter serverWriter,
+        StreamIterator<Frame> serverReader,
+        Future<Frame> Function() nextFrame,
+      ) async {
+        var settingsDone = Completer<void>();
+
+        Future serverFun() async {
+          serverWriter.writeSettingsFrame([]);
+          var frame = await nextFrame() as SettingsFrame;
+          var setting = frame.settings.firstWhere(
+            (s) => s.identifier == Setting.SETTINGS_MAX_HEADER_LIST_SIZE,
+          );
+          expect(setting.value, 256 * 1024);
+          serverWriter.writeSettingsAckFrame();
+          expect(await nextFrame(), isA<SettingsFrame>());
+          settingsDone.complete();
+          expect(
+            await nextFrame(),
+            isA<GoawayFrame>().having(
+              (f) => f.errorCode,
+              'errorCode',
+              ErrorCode.NO_ERROR,
+            ),
+          );
+          expect(await serverReader.moveNext(), false);
+        }
+
+        Future clientFun() async {
+          await settingsDone.future;
+          await client.finish();
+        }
+
+        await Future.wait([serverFun(), clientFun()]);
+      });
     });
 
     group('connection-operational', () {

--- a/pkgs/http2/test/src/frames/frame_defragmenter_test.dart
+++ b/pkgs/http2/test/src/frames/frame_defragmenter_test.dart
@@ -156,6 +156,38 @@ void main() {
         var f1 = continuationFrame([4, 5, 6], fragmented: true, streamId: 1);
         expect(defrag.tryDefragmentFrame(f1), equals(f1));
       });
+
+      test('fragmented-headers-frame--exceeds-max-size', () {
+        var defrag = FrameDefragmenter();
+
+        var f1 = headersFrame([1], fragmented: true);
+        var f2 = continuationFrame(
+          List<int>.filled(256 * 1024, 0),
+          fragmented: false,
+        );
+
+        expect(defrag.tryDefragmentFrame(f1), isNull);
+        expect(
+          () => defrag.tryDefragmentFrame(f2),
+          throwsA(isProtocolException),
+        );
+      });
+
+      test('fragmented-push-promise-frame--exceeds-max-size', () {
+        var defrag = FrameDefragmenter();
+
+        var f1 = pushPromiseFrame([1], fragmented: true);
+        var f2 = continuationFrame(
+          List<int>.filled(256 * 1024, 0),
+          fragmented: false,
+        );
+
+        expect(defrag.tryDefragmentFrame(f1), isNull);
+        expect(
+          () => defrag.tryDefragmentFrame(f2),
+          throwsA(isProtocolException),
+        );
+      });
     });
   });
 }

--- a/pkgs/http2/test/src/frames/frame_defragmenter_test.dart
+++ b/pkgs/http2/test/src/frames/frame_defragmenter_test.dart
@@ -173,20 +173,55 @@ void main() {
         );
       });
 
-      test('fragmented-push-promise-frame--exceeds-max-size', () {
-        var defrag = FrameDefragmenter();
+      test('fragmented-headers-frame--initial-exceeds-max-size', () {
+        var defrag = FrameDefragmenter(50);
 
-        var f1 = pushPromiseFrame([1], fragmented: true);
-        var f2 = continuationFrame(
-          List<int>.filled(256 * 1024, 0),
-          fragmented: false,
-        );
-
-        expect(defrag.tryDefragmentFrame(f1), isNull);
+        var f1 = headersFrame(List<int>.filled(51, 0), fragmented: true);
         expect(
-          () => defrag.tryDefragmentFrame(f2),
+          () => defrag.tryDefragmentFrame(f1),
           throwsA(isProtocolException),
         );
+      });
+
+      test('fragmented-push-promise-frame--initial-exceeds-max-size', () {
+        var defrag = FrameDefragmenter(50);
+
+        var f1 = pushPromiseFrame(List<int>.filled(51, 0), fragmented: true);
+        expect(
+          () => defrag.tryDefragmentFrame(f1),
+          throwsA(isProtocolException),
+        );
+      });
+
+      test('fragmented-headers-frame--custom-limit', () {
+        var defrag = FrameDefragmenter(10);
+
+        var f1 = headersFrame([1, 2, 3], fragmented: true);
+        var f2 = continuationFrame([4, 5, 6], fragmented: true);
+        var f3 = continuationFrame([7, 8, 9, 10, 11], fragmented: false);
+
+        expect(defrag.tryDefragmentFrame(f1), isNull);
+        expect(defrag.tryDefragmentFrame(f2), isNull);
+        expect(
+          () => defrag.tryDefragmentFrame(f3),
+          throwsA(isProtocolException),
+        );
+      });
+
+      test('fragmented-headers-frame--multi-chunks', () {
+        var defrag = FrameDefragmenter();
+
+        var f1 = headersFrame([1, 2], fragmented: true);
+        var f2 = continuationFrame([3, 4], fragmented: true);
+        var f3 = continuationFrame([5, 6], fragmented: true);
+        var f4 = continuationFrame([7, 8], fragmented: false);
+
+        expect(defrag.tryDefragmentFrame(f1), isNull);
+        expect(defrag.tryDefragmentFrame(f2), isNull);
+        expect(defrag.tryDefragmentFrame(f3), isNull);
+        var h = defrag.tryDefragmentFrame(f4) as HeadersFrame;
+        expect(h.hasEndHeadersFlag, isTrue);
+        expect(h.headerBlockFragment, [1, 2, 3, 4, 5, 6, 7, 8]);
       });
     });
   });

--- a/pkgs/http2/test/src/hpack/hpack_test.dart
+++ b/pkgs/http2/test/src/hpack/hpack_test.dart
@@ -780,6 +780,20 @@ void main() {
           0x84, 0x84, 0x84, 0x84, 0x84, 0x84, 0x84, 0x84, 0x84, 0x84,
         ]);
       });
+
+      test('maxHeaderListSize-within-limit', () {
+        var decoder = HPackDecoder(maxHeaderListSize: 100);
+        // :path: / -> name ':path' (5), value '/' (1), overhead (32) = 38
+        var headers = decoder.decode([0x84]);
+        expect(headers, hasLength(1));
+        expect(headers[0], isHeader(':path', '/'));
+      });
+
+      test('maxHeaderListSize-exceeded', () {
+        var decoder = HPackDecoder(maxHeaderListSize: 37);
+        // :path: / -> 5 + 1 + 32 = 38 > 37
+        expect(() => decoder.decode([0x84]), throwsA(isHPackDecodingException));
+      });
     });
   });
 }


### PR DESCRIPTION
Add `maxHeaderListSize` setting to `ClientSettings` and `ServerSettings` (defaulting to 256 KiB), advertise `SETTINGS_MAX_HEADER_LIST_SIZE`, enforce it during HPACK decoding, and limit CONTINUATION frame buffering with $O(N)$ defragmentation.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
