### PR TITLE
test(conformance): HEAD with content-length set

### DIFF
--- a/pkgs/http_client_conformance_tests/lib/src/response_headers_tests.dart
+++ b/pkgs/http_client_conformance_tests/lib/src/response_headers_tests.dart
@@ -235,6 +235,14 @@ void testResponseHeaders(Client Function() clientFactory,
         await expectLater(
             client.get(Uri.http(host, '')), throwsA(isA<ClientException>()));
       });
+
+      test('HEAD request', () async {
+        httpServerChannel.sink.add('content-length: 100\r\n');
+        final response = await client.head(Uri.http(host, ''));
+        expect(response.statusCode, 200);
+        expect(response.headers['content-length'], '100');
+        expect(response.body, '');
+      });
     });
 
     group('folded headers', () {


### PR DESCRIPTION
The failing `package:ok_http` tests are unrelated.

--

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
